### PR TITLE
Issue44 validate presence of start date for contest

### DIFF
--- a/app/models/contest.rb
+++ b/app/models/contest.rb
@@ -12,6 +12,7 @@ class Contest < ActiveRecord::Base
   validates :state, :length => { :maximum => 2 }
   validates :director, :length => { :maximum => 48 }
   validates :region, :length => { :maximum => 16 }
+  validates_presence_of :start
 
   def to_s
     "#{name} on #{start.strftime('%b %d, %Y')}"

--- a/spec/iac/soucy_computer_spec.rb
+++ b/spec/iac/soucy_computer_spec.rb
@@ -22,7 +22,7 @@ module IAC
       @c_ntnls = create(:contest, start: start,
         region: 'National',
         name: 'U.S. National Aerobatic Championships')
-      @c_mac = create(:contest, start: @start,
+      @c_mac = create(:contest, start: start,
         region: 'SouthCentral',
         name: 'MAC80 West')
 

--- a/spec/models/contest_spec.rb
+++ b/spec/models/contest_spec.rb
@@ -25,4 +25,55 @@ describe Contest, :type => :model do
     expect(contest.flights).to be_empty
     expect(contest.failures).to be_empty
   end
+
+  context 'validations' do
+    before :each do
+      @valid_params = {
+        'name' => 'Aéreo dust devil',
+        'start' => Date.today.to_s,
+        'city' => 'Daytona',
+        'state' => 'CA',
+        'director' => 'Cherry Garcia',
+        'region' => 'SouthWest'
+      }
+      @long_value = 'abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz'
+    end
+    it 'validates presence of contest name' do
+      @valid_params.delete('name')
+      contest = Contest.create(@valid_params)
+      expect(contest.valid?).to be false
+      expect(contest.errors['name']).to_not be_empty
+    end
+    it 'validates max length of contest name' do
+      contest = Contest.create(@valid_params.merge({name: @long_value}))
+      expect(contest.valid?).to be false
+      expect(contest.errors['name']).to_not be_empty
+    end
+    it 'validates max length of contest city' do
+      contest = Contest.create(@valid_params.merge({city: @long_value}))
+      expect(contest.valid?).to be false
+      expect(contest.errors['city']).to_not be_empty
+    end
+    it 'validates max length of contest state' do
+      contest = Contest.create(@valid_params.merge({state: 'USA'}))
+      expect(contest.valid?).to be false
+      expect(contest.errors['state']).to_not be_empty
+    end
+    it 'validates max length of contest director' do
+      contest = Contest.create(@valid_params.merge({director: @long_value}))
+      expect(contest.valid?).to be false
+      expect(contest.errors['director']).to_not be_empty
+    end
+    it 'validates max length of contest region' do
+      contest = Contest.create(@valid_params.merge({region: @long_value}))
+      expect(contest.valid?).to be false
+      expect(contest.errors['region']).to_not be_empty
+    end
+    it 'validates presence of contest start date' do
+      @valid_params.delete('start')
+      contest = Contest.create(@valid_params)
+      expect(contest.valid?).to be false
+      expect(contest.errors['start']).to_not be_empty
+    end
+  end
 end


### PR DESCRIPTION
Adds model validation tests for contest model.

Validates presence of a date. I don't want to rule out creating contests in the past, even far in the past.

Addresses issue #44 