### PR TITLE
Issue42: improve display of future contests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,13 @@
 language: ruby
 cache: bundler
-script: bundle exec rspec spec
 git:
   depth: 3
 before_script:
   - cmd/travis_ci_test_db.sh
   - RAILS_ENV='test' bundle exec rake db:setup
+script:
+  - bundle exec rspec spec
+  - bundle exec rake test
 after_script:
   - cmd/code_coverage_report.sh
 env:

--- a/Gemfile
+++ b/Gemfile
@@ -37,6 +37,7 @@ group :test do
   gem 'factory_bot_rails'
   gem 'database_cleaner'
   gem 'forgery'
+  gem 'timecop'
   gem 'capybara'
   gem 'launchy'
   gem 'capybara-webkit'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -200,6 +200,7 @@ GEM
     thor (0.20.0)
     thread_safe (0.3.6)
     tilt (2.0.8)
+    timecop (0.9.1)
     turnout (2.4.1)
       i18n (~> 0.7)
       rack (>= 1.3, < 3)
@@ -241,6 +242,7 @@ DEPENDENCIES
   selenium-webdriver
   simplecov
   therubyracer
+  timecop
   turnout
   uglifier
 

--- a/app/assets/stylesheets/contest.css
+++ b/app/assets/stylesheets/contest.css
@@ -4,3 +4,9 @@ p.category-chief,
 p.contest_place {
   margin-bottom: 0pt;
 }
+p.message {
+  margin-left: 3em;
+  margin-top: 2ex;
+  font-weight: bold;
+  font-size: larger;
+}

--- a/app/controllers/contests_controller.rb
+++ b/app/controllers/contests_controller.rb
@@ -8,7 +8,12 @@ class ContestsController < ApplicationController
     @years = Contest.select("distinct year(start) as anum").all.collect { |contest| contest.anum }
     @years.sort!{|a,b| b <=> a}
     @year = params[:year] || @years.first
-    @contests = Contest.where('year(start) = ?', @year).order("start DESC")
+    @contests = Contest.where(
+      'year(start) = ? and start <= now()', @year
+    ).order("start DESC")
+    @future_contests = Contest.where(
+      'year(start) = ? and now() < start', @year
+    ).order("start ASC")
   end
 
   # GET /contests/1

--- a/app/helpers/contests_helper.rb
+++ b/app/helpers/contests_helper.rb
@@ -1,2 +1,0 @@
-module ContestsHelper
-end

--- a/app/models/contest/show_results.rb
+++ b/app/models/contest/show_results.rb
@@ -20,9 +20,18 @@ module Contest::ShowResults
     flights_chiefs(flights.all)
   end
 
+  def is_future
+    Time.now() < (start + 2.days)
+  end
+
+  def place_and_time
+    base = is_future ? "Scheduled" : "Held"
+    "#{base} in #{place}, #{start}"
+  end
+
   def organizers
     orgs = []
-    orgs << "Directed by #{director}" if director
+    orgs << "Director: #{director}" if director
     orgs << "Chapter #{chapter}" if chapter != nil && 0 < chapter
     orgs.join(', ')
   end

--- a/app/views/contests/index.html.erb
+++ b/app/views/contests/index.html.erb
@@ -5,6 +5,16 @@
 <% end %>
 </p>
 
-<ul class="no-bullets">
-<%= render @contests %>
-</ul>
+<% unless @contests.empty? %>
+  <ul class="no-bullets">
+    <%= render @contests %>
+  </ul>
+<% end %>
+
+<% unless @future_contests.empty? %>
+  <h3>Future contests</h3>
+  <ul class="no-bullets future-contests">
+    <%= render @future_contests %>
+  </ul>
+<% end %>
+

--- a/app/views/contests/show.html.erb
+++ b/app/views/contests/show.html.erb
@@ -1,7 +1,7 @@
 <p id="notice"><%= notice %></p>
 
-<h1><%= @contest.name %></h1>
-<p class="contest_place">Held in <%= @contest.place %>, <%= @contest.start %></p>
+<h1><%= @contest.name %></h1
+<p class="contest_place"><%= @contest.place_and_time %></p>
 <% unless @contest.organizers.empty? %>
   <p class="contest_director"><%= @contest.organizers %></p>
 <% end %>
@@ -10,7 +10,7 @@
 <% end %>
 
 <% if @categories.empty? %>
-  <p>This contest has not posted any results.</p>
+  <p class='message'>This contest has not posted any results.</p>
 <% end %>
 
 <%= render :partial => 'contests/category', collection: @categories,

--- a/app/views/contests/show.html.erb
+++ b/app/views/contests/show.html.erb
@@ -9,6 +9,11 @@
   <p class="contest_chief">Chief Judge(s): <%= @contest.chief_names.join(', ') %></p>
 <% end %>
 
+<% if @categories.empty? %>
+  <p>This contest has not posted any results.</p>
+<% end %>
+
 <%= render :partial => 'contests/category', collection: @categories,
-  :locals => { no_category_chiefs: (@contest.chief_names.length < 2) } %>
+  :locals => { no_category_chiefs: (@contest.chief_names.length < 2) }
+%>
 

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -36,4 +36,7 @@ Rails.application.configure do
 
   # Raises error for missing translations
   config.action_view.raise_on_missing_translations = true
+
+  # Test in random order
+  config.active_support.test_order = :random
 end

--- a/spec/services/member_merge/merge_spec.rb
+++ b/spec/services/member_merge/merge_spec.rb
@@ -417,7 +417,7 @@ describe Merge, :type => :services do
     merge = MemberMerge::Merge.new(@mr_ids)
     bad_merge = proc { merge.execute_merge(mr_3) }
     expect(bad_merge).to raise_exception(ArgumentError) do |ex|
-      expect(ex.message).to contain('must be one of the members in the merge')
+      expect(ex.message).to match('must be one of the members in the merge')
     end
   end
 

--- a/spec/services/member_merge/merge_spec.rb
+++ b/spec/services/member_merge/merge_spec.rb
@@ -416,7 +416,9 @@ describe Merge, :type => :services do
     mr_3 = create(:member)
     merge = MemberMerge::Merge.new(@mr_ids)
     bad_merge = proc { merge.execute_merge(mr_3) }
-    expect(bad_merge).to raise_exception
+    expect(bad_merge).to raise_exception(ArgumentError) do |ex|
+      expect(ex.message).to contain('must be one of the members in the merge')
+    end
   end
 
   context 'many flights and roles' do

--- a/test/integration/contests/index_test.rb
+++ b/test/integration/contests/index_test.rb
@@ -1,0 +1,37 @@
+require 'test_helper'
+
+class ContestsIndexTest < ActionDispatch::IntegrationTest
+  setup do
+    Timecop.freeze
+    @refdate = Date.today
+    @contests = (-8 .. 8).map do |wct|
+      date = @refdate + wct.weeks
+      create(:contest, start: date)
+    end
+  end
+
+  teardown do
+    Timecop.return
+  end
+
+  test "future contests separated into future" do
+    visit contests_path
+    within('div#content') do
+      assert(page.has_xpath?("//h3[contains(text(),'Future contests')]"))
+      class_test = "contains(@class, 'future-contests')"
+      @contests.each do |contest|
+        list_item = page.find(:xpath,
+          "//li//a[@href='#{contest_path(contest.id)}']")
+        if contest.start <= @refdate
+          # contests started or completed
+          assert(list_item.has_xpath?("ancestor::ul[not(#{class_test})]"))
+          refute(list_item.has_xpath?("ancestor::ul[#{class_test}]"))
+        else
+          # future contests
+          refute(list_item.has_xpath?("ancestor::ul[not(#{class_test})]"))
+          assert(list_item.has_xpath?("ancestor::ul[#{class_test}]"))
+        end
+      end
+    end
+  end
+end

--- a/test/integration/contests/show_test.rb
+++ b/test/integration/contests/show_test.rb
@@ -1,11 +1,11 @@
 require 'test_helper'
 
-class ContestsTest < ActionDispatch::IntegrationTest
+class ContestsShowTest < ActionDispatch::IntegrationTest
   test "contest with no results" do
     contest = create(:contest)
     visit contest_path(contest.id)
     within('div#content') do
-      assert(page.body.include?('This contest has not posted any results.'))
+      assert(page.has_text?('This contest has not posted any results.'))
     end
   end
 end

--- a/test/integration/contests/show_test.rb
+++ b/test/integration/contests/show_test.rb
@@ -1,11 +1,28 @@
 require 'test_helper'
 
 class ContestsShowTest < ActionDispatch::IntegrationTest
-  test "contest with no results" do
+  test "contest with no results displays no results message" do
     contest = create(:contest)
     visit contest_path(contest.id)
     within('div#content') do
       assert(page.has_text?('This contest has not posted any results.'))
+      assert(page.has_css?('p.message'))
+    end
+  end
+
+  test "future contest says 'Scheduled'" do
+    contest = create(:contest, start: Date.today)
+    visit contest_path(contest.id)
+    within('div#content') do
+      assert(page.has_text?("Scheduled in #{contest.city}"))
+    end
+  end
+
+  test "current contest says 'Held in'" do
+    contest = create(:contest, start: Date.today - 3.days)
+    visit contest_path(contest.id)
+    within('div#content') do
+      assert(page.has_text?("Held in #{contest.city}"))
     end
   end
 end

--- a/test/integration/contests_test.rb
+++ b/test/integration/contests_test.rb
@@ -1,0 +1,11 @@
+require 'test_helper'
+
+class ContestsTest < ActionDispatch::IntegrationTest
+  test "contest with no results" do
+    contest = create(:contest)
+    visit contest_path(contest.id)
+    within('div#content') do
+      assert(page.body.include?('This contest has not posted any results.'))
+    end
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,0 +1,39 @@
+ENV["RAILS_ENV"] ||= "test"
+require File.expand_path("../../config/environment", __FILE__)
+require "rails/test_help"
+
+# Improved Minitest output (color and progress bar)
+#require "minitest/reporters"
+#Minitest::Reporters.use!(
+#  Minitest::Reporters::ProgressReporter.new,
+#  ENV,
+#  Minitest.backtrace_filter)
+
+# FactoryBot
+class ActiveSupport::TestCase
+  include FactoryBot::Syntax::Methods
+end
+
+# Capybara
+require "capybara/rails"
+require "capybara/minitest"
+require "capybara/webkit"
+
+Capybara.configure do |config|
+  config.javascript_driver = :webkit
+end
+
+Capybara::Webkit.configure do |config|
+  config.block_unknown_urls
+end
+
+class ActionDispatch::IntegrationTest
+  include Capybara::DSL
+  include Capybara::Minitest::Assertions
+
+  def teardown
+    Capybara.reset_sessions!
+    Capybara.use_default_driver
+  end
+end
+


### PR DESCRIPTION
Addresses issue #42 

This separates contests with future dates in the index.

It displays a "no results yet posted" message in the contest view if there are no contest results.

Adds support for Rails standard Minitest because I'm sick to death of RSpec.