### PR TITLE
Switch from Forgery to Faker for Unique capability

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -36,7 +36,7 @@ end
 group :test do
   gem 'factory_bot_rails'
   gem 'database_cleaner'
-  gem 'forgery'
+  gem 'faker'
   gem 'timecop'
   gem 'capybara'
   gem 'launchy'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -83,8 +83,9 @@ GEM
     factory_bot_rails (4.8.2)
       factory_bot (~> 4.8.2)
       railties (>= 3.0.0)
+    faker (1.8.7)
+      i18n (>= 0.7)
     ffi (1.9.23)
-    forgery (0.7.0)
     foundation-rails (6.4.3.0)
       railties (>= 3.1.0)
       sass (>= 3.3.0, < 3.5)
@@ -227,7 +228,7 @@ DEPENDENCIES
   delayed_job
   delayed_job_active_record
   factory_bot_rails
-  forgery
+  faker
   foundation-rails
   jbuilder
   jquery-rails

--- a/spec/factories/model.rb
+++ b/spec/factories/model.rb
@@ -2,20 +2,18 @@
 FactoryBot.define do
 ### Airplane
   factory :airplane do |r|
-    r.sequence(:make) { Forgery(:name).company_name }
-    r.sequence(:model) { Forgery(:name).company_name }
+    r.sequence(:make) { Faker::Company.unique.name }
+    r.sequence(:model) { Faker::Company.unique.name }
     r.sequence(:reg) do
-      Forgery(:basic).number(:at_least => 100, :at_most => 999).to_s +
-      Forgery(:basic).text(at_least: 2, at_most: 2, allow_lower: false,
-        allow_numeric: false)
+      Faker::Number.between(100, 999).to_s +
+      Faker::Name.initials(2)
     end
   end
 ### Member
   factory :member do |r|
-    r.sequence(:iac_id) { |i| 10 ** Forgery(:basic).number(
-      at_least: 2, at_most: 6) + i }
-    r.sequence(:family_name) { |i| Forgery(:name).last_name }
-    r.sequence(:given_name) { |i| Forgery(:name).first_name }
+    r.sequence(:iac_id) { |i| 10 ** Faker::Number.between(2, 6) + i }
+    family_name { Faker::Name.last_name }
+    given_name { Faker::Name.first_name }
   end
   factory :tom_adams, :class => Member do |r|
     r.iac_id 1999
@@ -70,17 +68,19 @@ FactoryBot.define do
     r.director 'Vicky Benzing'
   end
   factory :contest do |r|
-    r.name { Forgery(:name).company_name + ' Aerobatic Open' }
-    r.city Forgery(:address).city
+    r.name {
+      [
+        Faker::Superhero.descriptor,
+        'Aerobatic',
+        Faker::LeagueOfLegends.summoner_spell
+      ].join(' ')
+    }
+    r.city Faker::Address.city
     r.region 'SouthEast'
     r.chapter '52'
-    r.state Forgery(:address).state_abbrev
-    r.start Time.mktime(
-      Forgery(:basic).number(at_least: 2011, at_most: 2020),
-      Forgery(:basic).number(at_least: 1, at_most: 12),
-      Forgery(:basic).number(at_least: 1, at_most: 28)
-    )
-    r.director Forgery(:name).full_name
+    r.state Faker::Address.state_abbr
+    r.start Faker::Date.between(6.years.ago, 3.years.from_now)
+    r.director Faker::Name.name
   end
 ### Category
   factory :category do

--- a/spec/support/faker.rb
+++ b/spec/support/faker.rb
@@ -1,0 +1,5 @@
+RSpec.configure do |config|
+  config.after :example do
+    Faker::UniqueGenerator.clear
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -14,6 +14,11 @@ class ActiveSupport::TestCase
   include FactoryBot::Syntax::Methods
 end
 
+# Faker Unique
+Minitest.after_run do
+  Faker::UniqueGenerator.clear
+end
+
 # Capybara
 require "capybara/rails"
 require "capybara/minitest"


### PR DESCRIPTION
By random chance the make and model factory could produce a duplicate.

Switched to Faker to generate the random model name uniquely, so this won't happen again.