### PR TITLE
Test and improve JaSPer contest information parsing

### DIFF
--- a/app/services/jasper/jasper_parse.rb
+++ b/app/services/jasper/jasper_parse.rb
@@ -17,38 +17,41 @@ class JasperParse
   end
 
   def contest_name
-    nodes = @document.find('/ContestResults/ContestInfo/Contest')
-    nodes && nodes.first ? nodes.first.inner_xml : ''
+    clean_text(@document.find('/ContestResults/ContestInfo/Contest'))
   end
 
   def contest_date
     nodes = @document.find('/ContestResults/ContestInfo/Date')
     text = nodes && nodes.first ? nodes.first.inner_xml : nil
+    start = nil
     if text
-      Date.strptime(text, '%m/%d/%y')
-    else
-      nil
+      begin
+        start = Date.strptime(text, '%m/%d/%y')
+      rescue ArgumentError
+        begin
+          start = Date.strptime(text, '%Y-%m-%d')
+        rescue ArgumentError
+          start = nil
+        end
+      end
     end
+    start
   end
 
   def contest_region
-    nodes = @document.find('/ContestResults/ContestInfo/Region')
-    nodes && nodes.first ? nodes.first.inner_xml : ''
+    clean_text(@document.find('/ContestResults/ContestInfo/Region'))
   end
 
   def contest_director
-    nodes = @document.find('/ContestResults/ContestInfo/Director')
-    nodes && nodes.first ? nodes.first.inner_xml : ''
+    clean_text(@document.find('/ContestResults/ContestInfo/Director'))
   end
 
   def contest_city
-    nodes = @document.find('/ContestResults/ContestInfo/City')
-    nodes && nodes.first ? nodes.first.inner_xml : ''
+    clean_text(@document.find('/ContestResults/ContestInfo/City'))
   end
 
   def contest_state
-    nodes = @document.find('/ContestResults/ContestInfo/State')
-    nodes && nodes.first ? nodes.first.inner_xml : ''
+    clean_text(@document.find('/ContestResults/ContestInfo/State'))
   end
 
   def contest_chapter
@@ -57,8 +60,8 @@ class JasperParse
   end
 
   def aircat
-    nodes = @document.find('/ContestResults/ContestInfo/Type')
-    type = nodes && nodes.first ? nodes.first.inner_xml : 'Powered'
+    type = clean_text(@document.find('/ContestResults/ContestInfo/Type'))
+    type = 'Powered' if type.empty?
     type[0,1]
   end
 
@@ -312,6 +315,11 @@ class JasperParse
     else
       ''
     end
+  end
+
+  def clean_text(nodes)
+    text = nodes && nodes.first ? nodes.first.inner_xml : nil
+    text.nil? ? '' : text
   end
 
 end #class

--- a/app/services/jasper/jasper_to_db.rb
+++ b/app/services/jasper/jasper_to_db.rb
@@ -22,7 +22,7 @@ def process_contest(jasper, contest_id = nil)
   if (contest_id)
     @d_contest = updateOrCreateContest(contest_id, contest_params)
   else
-    @d_contest = Contest.create(contest_params)
+    @d_contest = Contest.create!(contest_params)
   end
   if d_contest
     process_scores(d_contest, jasper)
@@ -34,8 +34,9 @@ end
 
 def extract_contest_params_hash(jasper)
   contest_params = {};
-  contest_params['name'] = jasper.contest_name.strip.slice(0,48) || 'missing contest name'
-  contest_params['start'] = jasper.contest_date
+  name = jasper.contest_name.strip.slice(0,48)
+  contest_params['name'] = name.blank? ? 'missing contest name' : name
+  contest_params['start'] = jasper.contest_date || Date.today
   contest_params['region'] = jasper.contest_region.strip.slice(0,16)
   contest_params['director'] = jasper.contest_director.strip.slice(0,48)
   contest_params['city'] = jasper.contest_city.strip.slice(0,24)
@@ -50,7 +51,7 @@ def updateOrCreateContest(id, contest_params)
     d_contest.reset_to_base_attributes
     d_contest.update_attributes(contest_params)
   rescue ActiveRecord::RecordNotFound
-    d_contest = Contest.create(contest_params)
+    d_contest = Contest.create!(contest_params)
   end
   d_contest
 end

--- a/test/services/jasper/blank_contest_to_db_test.rb
+++ b/test/services/jasper/blank_contest_to_db_test.rb
@@ -1,0 +1,32 @@
+require 'test_helper'
+require_relative 'contest_data'
+
+class BlankContestToDbTest < ActiveSupport::TestCase
+  include ContestData
+
+  setup do
+    @jasper = parse_contest_data(blank_empty_contest)
+    @j2db = Jasper::JasperToDB.new
+  end
+
+  test 'extract params' do
+    now = Date.today
+    Timecop.freeze(now) do
+      params = @j2db.extract_contest_params_hash(@jasper)
+      assert_equal('missing contest name', params['name'])
+      assert_equal(Date.today, params['start'])
+      assert_empty(params['region'])
+      assert_empty(params['director'])
+      assert_empty(params['city'])
+      assert_empty(params['state'])
+      assert_empty(params['chapter'])
+    end
+  end
+
+  test 'creates new contest' do
+    contest = @j2db.process_contest(@jasper)
+    refute_nil(contest)
+    refute_nil(contest.id)
+    assert_equal(1, Contest.count)
+  end
+end

--- a/test/services/jasper/contest_data.rb
+++ b/test/services/jasper/contest_data.rb
@@ -1,0 +1,36 @@
+require 'libxml'
+
+module ContestData
+  def parse_contest_data(data)
+    parser = LibXML::XML::Parser.string(data)
+    jasper = Jasper::JasperParse.new
+    jasper.do_parse(parser)
+    jasper
+  end
+
+  def blank_empty_contest(params = {})
+    return <<~EXML
+      <?xml version="1.0"?>
+      <ContestResults>
+        <Version>
+           <XMLFormat>1.0</XMLFormat>
+           <JaSPer>3.2.31</JaSPer>
+           <Generated>Sat May 05 14:15:50 PDT 2018</Generated>
+        </Version>
+        <ContestInfo>
+          <Id>#{params.fetch(:id,'')}</Id>
+          <cdbId>#{params.fetch(:cbd_id,'')}</cdbId>
+          <Contest>#{params.fetch(:name,'')}</Contest>
+          <City>#{params.fetch(:city,'')}</City>
+          <State>#{params.fetch(:state,'')}</State>
+          <Date>#{params.fetch(:start,'')}</Date>
+          <Director>#{params.fetch(:director,'')}</Director>
+          <HostChapter>#{params.fetch(:chapter,'')}</HostChapter>
+          <Region>#{params.fetch(:region,'')}</Region>
+          <Type>#{params.fetch(:type,'')}</Type>
+          <Comment>#{params.fetch(:comment,'')}</Comment>
+        </ContestInfo>
+      </ContestResults>
+    EXML
+  end
+end

--- a/test/services/jasper/parse/blank_contest_test.rb
+++ b/test/services/jasper/parse/blank_contest_test.rb
@@ -1,0 +1,41 @@
+require 'test_helper'
+require_relative '../contest_data'
+
+class BlankContestTest < ActiveSupport::TestCase
+  include ContestData
+
+  setup do
+    @jasper = parse_contest_data(blank_empty_contest)
+  end
+
+  test 'string fields return a value' do
+    refute_nil(@jasper.contest_name)
+    refute_nil(@jasper.contest_city)
+    refute_nil(@jasper.contest_state)
+    refute_nil(@jasper.contest_chapter)
+    refute_nil(@jasper.contest_region)
+    refute_nil(@jasper.contest_director)
+    refute_nil(@jasper.aircat)
+  end
+
+  test 'contest id returns nil' do
+    assert_nil(@jasper.contest_id)
+  end
+
+  test 'contest date returns nil' do
+    assert_nil(@jasper.contest_date)
+  end
+
+  test 'aircat returns default' do
+    assert_equal('P', @jasper.aircat)
+  end
+
+  test 'string fields are blank' do
+    assert_empty(@jasper.contest_name)
+    assert_empty(@jasper.contest_city)
+    assert_empty(@jasper.contest_state)
+    assert_empty(@jasper.contest_chapter)
+    assert_empty(@jasper.contest_region)
+    assert_empty(@jasper.contest_director)
+  end
+end

--- a/test/services/jasper/parse/start_date_test.rb
+++ b/test/services/jasper/parse/start_date_test.rb
@@ -1,0 +1,28 @@
+require 'test_helper'
+require_relative '../contest_data'
+
+class StartDateTest < ActiveSupport::TestCase
+  include ContestData
+
+  test 'parses yyyy-mm-dd date format' do
+    now = Date.today
+    Timecop.freeze(now) do
+      jasper = parse_contest_data(blank_empty_contest({
+        start: now.strftime('%Y-%m-%d')
+      }))
+      assert_equal(now, jasper.contest_date)
+    end
+  end
+
+  test 'parses m/d/yy date format' do
+    now = Date.today
+    Timecop.freeze(now) do
+      jasper = parse_contest_data(blank_empty_contest({
+        start: now.strftime('%m/%d/%y')
+      }))
+      assert_equal(now, jasper.contest_date)
+    end
+  end
+
+
+end


### PR DESCRIPTION
Resolves issue #63 

Enables YYYY-MM-DD date format.

Resolves-- contest would silently fail create --bug discovered in testing.