### PR TITLE
Show in contest list whether contest has results

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -39,7 +39,6 @@ group :test do
   gem 'timecop'
   gem 'capybara'
   gem 'launchy'
-  gem 'capybara-webkit'
   gem 'selenium-webdriver'
   gem 'simplecov'
   gem 'codeclimate-test-reporter', '~> 1.0.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -53,9 +53,6 @@ GEM
       rack (>= 1.6.0)
       rack-test (>= 0.6.3)
       xpath (~> 3.0)
-    capybara-webkit (1.15.0)
-      capybara (>= 2.3, < 4.0)
-      json
     childprocess (0.9.0)
       ffi (~> 1.0, >= 1.0.11)
     chronic (0.10.2)
@@ -236,7 +233,6 @@ PLATFORMS
 
 DEPENDENCIES
   capybara
-  capybara-webkit
   chronic
   codeclimate-test-reporter (~> 1.0.0)
   coffee-rails
@@ -267,4 +263,4 @@ DEPENDENCIES
   uglifier
 
 BUNDLED WITH
-   1.16.4
+   1.16.6

--- a/README.md
+++ b/README.md
@@ -1,10 +1,63 @@
-[![Travis Test Status](https://travis-ci.org/wbreeze/iaccdb.svg)](https://travis-ci.org/wbreeze/iaccdb)
-[![Test Coverage](https://codeclimate.com/github/wbreeze/iaccdb/badges/coverage.svg)](https://codeclimate.com/github/wbreeze/iaccdb/coverage)
-[![Code Climate](https://codeclimate.com/github/wbreeze/iaccdb/badges/gpa.svg)](https://codeclimate.com/github/wbreeze/iaccdb)
+[![Travis Test Status](https://travis-ci.org/wbreeze/iaccdb.svg)](
+https://travis-ci.org/wbreeze/iaccdb)
+[![Test Coverage](https://codeclimate.com/github/wbreeze/iaccdb/badges/coverage.svg)](
+https://codeclimate.com/github/wbreeze/iaccdb/coverage)
+[![Code Climate](https://codeclimate.com/github/wbreeze/iaccdb/badges/gpa.svg)](
+https://codeclimate.com/github/wbreeze/iaccdb)
 
 This project contains code for a Ruby-on-Rails web site that displays data
-about Aerobatic Contests, including contest results, pilot standings, and judge metrics.
+about aerobatic contests, including contest results, pilot standings,
+and judge metrics.
 
-Find the site deployed at http://iaccdb.iac.org/
+Find this deployed on the [web site](https://iaccdb.iac.org/)
+of the International Aerobatic Club (IAC).
 
-For more information contact Douglas Lovell, doug@wbreeze.com
+For more information contact [Douglas Lovell](https://github.com/wbreeze)
+
+## Development
+
+To make this work locally:
+
+ - [Fork the repository](https://guides.github.com/activities/forking/)
+   and clone it to your workspace
+ - Have installed mysql
+ - Have installed ruby, rubygems, and bundler.
+   Ruby ought to be the version specified by `.ruby-version`.
+   We find [rbenv](https://github.com/rbenv/rbenv) to be most useful.
+   ```
+   rbenv install `cat .ruby-version`
+   gem install bundler
+   ```
+ - Copy the `config/database.yml.sample` to `config/database.yml`
+ - In the mysql client (`> mysql -u root`):
+     - create the `cdb_dev` and `cdb_test` databases
+       ```sql
+       mysql> create database cdb_dev;`
+       ```
+     - create the `cdbusr` user with global permissions to the two databases
+       ```sql
+       mysql> create user 'cdbusr'@'localhost' identified by 'ei9vDmJN';
+       mysql> grant all privileges on cdb_dev.* to 'cdbusr'@'localhost';
+       mysql> grant all privileges on cdb_test.* to 'cdbusr'@'localhost';
+       ```
+       The password in the "`create user`" command matches that
+       in `database.yml`.  The user name, "`cdbuser`" matches
+       that in `database.yml`.
+ - Install the gems: `bundle install`
+ - Run the Rails database setup script: `rails db:setup`
+
+Having done that,
+ - The command "`rspec spec`" should run the older tests.
+ - The command "`rails test`" should run the newer tests.
+ - The command "`rails server`" should
+   start a server at `http://localhost:3000`.
+
+## Contributions
+
+We follow [GitHub Flow](https://guides.github.com/introduction/flow/).
+Any pull request you make will receive a response.
+[Issue fixes](https://github.com/wbreeze/iaccdb/issues) are welcome,
+especially when they include tests. Tests are welcome.
+If your contribution
+might require significant time and effort,
+it's safest to get in touch first with your proposal.

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ To make this work locally:
    rbenv install `cat .ruby-version`
    gem install bundler
    ```
+ - Copy the `config/admin.yml.sample` to `config/admin.yml`
  - Copy the `config/database.yml.sample` to `config/database.yml`
  - In the mysql client (`> mysql -u root`):
      - create the `cdb_dev` and `cdb_test` databases

--- a/app/assets/stylesheets/contest.css
+++ b/app/assets/stylesheets/contest.css
@@ -10,3 +10,6 @@ p.message {
   font-weight: bold;
   font-size: larger;
 }
+span.missing-results {
+  font-weight: bold;
+}

--- a/app/controllers/contests_controller.rb
+++ b/app/controllers/contests_controller.rb
@@ -13,7 +13,7 @@ class ContestsController < ApplicationController
     @year = params[:year] || default_year(@years.first)
     @contests = Contest.where(
       'year(start) = ? and start <= now()', @year
-    ).order("start DESC")
+    ).order("start DESC").includes(:flights)
     @future_contests = Contest.where(
       'year(start) = ? and now() < start', @year
     ).order("start ASC")

--- a/app/views/contests/_contest.html.erb
+++ b/app/views/contests/_contest.html.erb
@@ -1,5 +1,13 @@
-    <li><%= contest.start %>
-    <%= link_to contest.sobriquet, contest %>
-    <%= contest.place %>.
-    Directed by <%= contest.director %>,
-    Chapter <%= contest.chapter %></li>
+<li><%= contest.start %>
+  <%= link_to contest.sobriquet, contest %>
+  <%= contest.place %>.
+  <%= "Directed by #{contest.director}" unless contest.director.blank? %><%=
+    ", Chapter #{contest.chapter}" unless contest.chapter.blank?
+  %><% if post_date
+    flight = contest.flights.first
+    if flight %><%= ", computed #{flight.created_at}"
+    %><% else %><%= ',' %>
+      <span class='missing-results'>no results</span>
+    <% end
+  end %>
+</li>

--- a/app/views/contests/index.html.erb
+++ b/app/views/contests/index.html.erb
@@ -7,14 +7,22 @@
 
 <% unless @contests.empty? %>
   <ul class="contests no-bullets">
-    <%= render @contests %>
+    <%= render(
+      partial: 'contest',
+      collection: @contests,
+      locals: { post_date: true }
+    ) %>
   </ul>
 <% end %>
 
 <% unless @future_contests.empty? %>
   <h3>Future contests</h3>
   <ul class="no-bullets future-contests">
-    <%= render @future_contests %>
+    <%= render(
+      partial: 'contest',
+      collection: @future_contests,
+      locals: { post_date: false }
+    )%>
   </ul>
 <% end %>
 

--- a/config/admin.yml.sample
+++ b/config/admin.yml.sample
@@ -1,0 +1,9 @@
+---
+# users with passwords, and roles for http auth
+users:
+  - name: contest_admin
+    password: antOehiRl,c.ygkw0vmb
+    role: admin
+  - name: calendar_admin
+    password: lPcigwVm;xbq056alr34ocugf
+    role: contest_admin

--- a/spec/acro/contest_reader_spec.rb
+++ b/spec/acro/contest_reader_spec.rb
@@ -106,7 +106,10 @@ module ACRO
       ct = Contest.where(:start => '2011-09-25').first
       fla = ct.flights
       expect(fla.size).to eq(4)
-      expect(fla.first.pilot_flights.size).to eq(2)
+      fps = fla.collect do |f|
+        f.pilot_flights.size
+      end
+      expect(fps).to match_array([1, 2, 2, 2])
     end
 
     it 'stores the penalty' do

--- a/spec/factories/model.rb
+++ b/spec/factories/model.rb
@@ -79,10 +79,10 @@ FactoryBot.define do
     r.director 'Vicky Benzing'
   end
   factory :contest do
-    name contest_name
+    name { contest_name }
     city { Faker::Address.city }
-    region region_name
-    chapter chapter_number
+    region { region_name }
+    chapter { chapter_number }
     state { Faker::Address.state_abbr }
     start { Faker::Date.between(6.years.ago, 3.years.from_now) }
     director { Faker::Name.name }

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -1,15 +1,5 @@
 # Configure Capybara
 # https://github.com/jnicklas/capybara
-Capybara.configure do |config|
-  #config.wait_on_first_by_default = true # on master, coming in the future
-  #config.javascript_driver = :selenium # default
-  config.javascript_driver = :webkit
-  #config.default_wait_time = 15
-end
-
-Capybara::Webkit.configure do |config|
-  config.block_unknown_urls
-end
 
 RSpec.configure do |config|
   # when viz: true is on the scenario, e.g.

--- a/test/integration/contests/index_test.rb
+++ b/test/integration/contests/index_test.rb
@@ -14,33 +14,74 @@ class ContestsIndexTest < ActionDispatch::IntegrationTest
     Timecop.return
   end
 
-  test "future contests separated into future" do
+  def contest_item_link_selector(contest)
+    "//li//a[@href='#{contest_path(contest)}']"
+  end
+
+  def contest_item_link(contest)
+    page.find(:xpath, contest_item_link_selector(contest))
+  end
+
+  def future_contest_item(item_link)
+    item_link.has_xpath?('ancestor::ul[contains(@class, "future-contests")]')
+  end
+
+  test 'future contests separated into future' do
     visit contests_path
     within('div#content') do
-      assert(page.has_xpath?("//h3[contains(text(),'Future contests')]"))
-      class_test = "contains(@class, 'future-contests')"
+      assert(page.has_xpath?('//h3[contains(text(),"Future contests")]'))
       @contests.each do |contest|
-        list_item = page.find(:xpath,
-          "//li//a[@href='#{contest_path(contest.id)}']")
+        item_link = contest_item_link(contest)
+        assert(item_link)
         if contest.start <= @refdate
           # contests started or completed
-          assert(list_item.has_xpath?("ancestor::ul[not(#{class_test})]"))
-          refute(list_item.has_xpath?("ancestor::ul[#{class_test}]"))
+          refute(future_contest_item(item_link))
         else
           # future contests
-          refute(list_item.has_xpath?("ancestor::ul[not(#{class_test})]"))
-          assert(list_item.has_xpath?("ancestor::ul[#{class_test}]"))
+          assert(future_contest_item(item_link))
         end
       end
     end
   end
 
-  test "contests shown for current year" do
+  test 'contests shown for current year' do
     future_season_contest = create :contest, year: @refdate.year + 1
     visit contests_path
-    refute(page.has_xpath?(
-      "//li//a[@href='#{contest_path(future_season_contest.id)}']"))
-    assert(page.has_xpath?(
-      "//li//a[@href='#{contest_path(@contests.first.id)}']"))
+    refute(page.has_xpath?(contest_item_link_selector(future_season_contest)))
+    assert(contest_item_link(@contests.first))
+  end
+
+  test 'post contests show post date when posted' do
+    contest_with_flight = create(:contest, start: @refdate - 1.week)
+    flight = create :flight, contest: contest_with_flight
+    visit contests_path
+    item_link = contest_item_link(contest_with_flight)
+    refute(future_contest_item(item_link))
+    assert(item_link.has_xpath?(
+      "following-sibling::text()[contains(., 'computed #{flight.created_at}')]"
+    ))
+  end
+
+  test 'post contests show not yet posted' do
+    contest = create(:contest, start: @refdate - 1.week)
+    visit contests_path
+    item_link = contest_item_link(contest)
+    refute(future_contest_item(item_link))
+    assert(item_link.has_xpath?(
+      'following-sibling::*[contains(@class, "missing-results")]'
+    ))
+  end
+
+  test 'future contests do not show not posted' do
+    contest = create(:contest, start: @refdate + 1.week)
+    visit contests_path
+    item_link = contest_item_link(contest)
+    assert(future_contest_item(item_link))
+    refute(item_link.has_xpath?(
+      'following-sibling::*[contains(@class, "missing-results")]'
+    ))
+    refute(item_link.has_xpath?(
+      'following-sibling::text()[contains(., "computed")]'
+    ))
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -26,14 +26,9 @@ require 'shoulda/context'
 # Capybara
 require "capybara/rails"
 require "capybara/minitest"
-require "capybara/webkit"
 
 Capybara.configure do |config|
-  config.javascript_driver = :webkit
-end
-
-Capybara::Webkit.configure do |config|
-  config.block_unknown_urls
+  config.javascript_driver = :selenium
 end
 
 class ActionDispatch::IntegrationTest


### PR DESCRIPTION
Changes to resolve #59 

We show the date of the first posted instead of the posting date. Nationals, for example, doesn't have a post.  One drawback is that recomputation creates a new flight. Or does it? We say "computed " instead of posted. We say "no results" if there are no flights.

We also snuck-in documentation about how to develop on this project. And replaced webkit with selenium for integration tests. Rightly, those belong in separate PR's.