### PR TITLE
Limit length of make and model columns

### DIFF
--- a/db/migrate/20190828202737_make_model_key_length.rb
+++ b/db/migrate/20190828202737_make_model_key_length.rb
@@ -1,0 +1,12 @@
+class MakeModelKeyLength < ActiveRecord::Migration[5.1]
+  reversible do |dir|
+    dir.up do
+      change_column :make_models, :make, :string, limit: 80
+      change_column :make_models, :model, :string, limit: 80
+    end
+    dir.down do
+      change_column :make_models, :make, :string
+      change_column :make_models, :model, :string
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -12,7 +12,7 @@
 
 ActiveRecord::Schema.define(version: 20190828210615) do
 
-  create_table "airplanes", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci" do |t|
+  create_table "airplanes", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci" do |t|
     t.string "make"
     t.string "model"
     t.string "reg"
@@ -22,7 +22,7 @@ ActiveRecord::Schema.define(version: 20190828210615) do
     t.index ["id"], name: "index_airplanes_on_id"
   end
 
-  create_table "categories", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci" do |t|
+  create_table "categories", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci" do |t|
     t.integer "sequence", null: false
     t.string "category", limit: 16, null: false
     t.string "aircat", limit: 1, null: false
@@ -32,7 +32,7 @@ ActiveRecord::Schema.define(version: 20190828210615) do
     t.index ["id"], name: "index_categories_on_id"
   end
 
-  create_table "contests", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci" do |t|
+  create_table "contests", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci" do |t|
     t.string "name", limit: 48
     t.string "city", limit: 24
     t.string "state", limit: 2
@@ -45,7 +45,7 @@ ActiveRecord::Schema.define(version: 20190828210615) do
     t.index ["id"], name: "index_contests_on_id"
   end
 
-  create_table "data_posts", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci" do |t|
+  create_table "data_posts", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci" do |t|
     t.integer "contest_id"
     t.boolean "is_integrated", default: false
     t.boolean "has_error", default: false
@@ -57,7 +57,7 @@ ActiveRecord::Schema.define(version: 20190828210615) do
     t.index ["id"], name: "index_data_posts_on_id"
   end
 
-  create_table "delayed_jobs", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci" do |t|
+  create_table "delayed_jobs", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci" do |t|
     t.integer "priority", default: 0
     t.integer "attempts", default: 0
     t.text "handler", limit: 16777215
@@ -72,7 +72,7 @@ ActiveRecord::Schema.define(version: 20190828210615) do
     t.index ["priority", "run_at"], name: "delayed_jobs_priority"
   end
 
-  create_table "failures", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci" do |t|
+  create_table "failures", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci" do |t|
     t.string "step", limit: 16
     t.integer "contest_id"
     t.integer "manny_id"
@@ -86,7 +86,7 @@ ActiveRecord::Schema.define(version: 20190828210615) do
     t.index ["manny_id"], name: "index_failures_on_manny_id"
   end
 
-  create_table "flights", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci" do |t|
+  create_table "flights", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci" do |t|
     t.integer "contest_id", null: false
     t.string "name", limit: 16, null: false
     t.integer "sequence", null: false
@@ -102,7 +102,7 @@ ActiveRecord::Schema.define(version: 20190828210615) do
     t.index ["id"], name: "index_flights_on_id"
   end
 
-  create_table "jc_results", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci" do |t|
+  create_table "jc_results", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci" do |t|
     t.integer "judge_id", null: false
     t.integer "pilot_count"
     t.decimal "sigma_ri_delta", precision: 11, scale: 5
@@ -129,7 +129,7 @@ ActiveRecord::Schema.define(version: 20190828210615) do
     t.index ["judge_id"], name: "index_jc_results_on_judge_id"
   end
 
-  create_table "jf_results", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci" do |t|
+  create_table "jf_results", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci" do |t|
     t.integer "judge_id"
     t.integer "pilot_count"
     t.decimal "sigma_ri_delta", precision: 10, scale: 5
@@ -154,7 +154,7 @@ ActiveRecord::Schema.define(version: 20190828210615) do
     t.index ["judge_id"], name: "index_jf_results_on_judge_id"
   end
 
-  create_table "judges", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci" do |t|
+  create_table "judges", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci" do |t|
     t.integer "judge_id"
     t.integer "assist_id"
     t.datetime "created_at"
@@ -164,7 +164,7 @@ ActiveRecord::Schema.define(version: 20190828210615) do
     t.index ["judge_id"], name: "index_judges_on_judge_id"
   end
 
-  create_table "jy_results", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci" do |t|
+  create_table "jy_results", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci" do |t|
     t.integer "judge_id"
     t.integer "category_id"
     t.integer "year"
@@ -190,9 +190,9 @@ ActiveRecord::Schema.define(version: 20190828210615) do
     t.index ["judge_id"], name: "index_jy_results_on_judge_id"
   end
 
-  create_table "make_models", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci" do |t|
-    t.string "make"
-    t.string "model"
+  create_table "make_models", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci" do |t|
+    t.string "make", limit: 80
+    t.string "model", limit: 80
     t.integer "empty_weight_lbs", limit: 2
     t.integer "max_weight_lbs", limit: 2
     t.integer "horsepower", limit: 2
@@ -204,7 +204,7 @@ ActiveRecord::Schema.define(version: 20190828210615) do
     t.index ["model"], name: "index_make_models_on_model"
   end
 
-  create_table "manny_synches", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci" do |t|
+  create_table "manny_synches", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci" do |t|
     t.integer "contest_id"
     t.integer "manny_number"
     t.datetime "synch_date"
@@ -213,7 +213,7 @@ ActiveRecord::Schema.define(version: 20190828210615) do
     t.index ["contest_id"], name: "index_manny_synches_on_contest_id"
   end
 
-  create_table "members", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci" do |t|
+  create_table "members", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci" do |t|
     t.integer "iac_id"
     t.string "given_name", limit: 40
     t.string "family_name", limit: 40
@@ -223,7 +223,7 @@ ActiveRecord::Schema.define(version: 20190828210615) do
     t.index ["id"], name: "index_members_on_id"
   end
 
-  create_table "pc_results", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci" do |t|
+  create_table "pc_results", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci" do |t|
     t.integer "pilot_id", null: false
     t.decimal "category_value", precision: 8, scale: 2
     t.integer "category_rank"
@@ -241,7 +241,7 @@ ActiveRecord::Schema.define(version: 20190828210615) do
     t.index ["pilot_id"], name: "index_pc_results_on_pilot_id"
   end
 
-  create_table "pf_results", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci" do |t|
+  create_table "pf_results", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci" do |t|
     t.integer "pilot_flight_id", null: false
     t.decimal "flight_value", precision: 7, scale: 2
     t.decimal "adj_flight_value", precision: 7, scale: 2
@@ -257,7 +257,7 @@ ActiveRecord::Schema.define(version: 20190828210615) do
     t.index ["pilot_flight_id"], name: "index_pf_results_on_pilot_flight_id"
   end
 
-  create_table "pfj_results", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci" do |t|
+  create_table "pfj_results", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci" do |t|
     t.integer "pilot_flight_id", null: false
     t.integer "judge_id", null: false
     t.string "computed_values"
@@ -274,7 +274,7 @@ ActiveRecord::Schema.define(version: 20190828210615) do
     t.index ["pilot_flight_id"], name: "index_pfj_results_on_pilot_flight_id"
   end
 
-  create_table "pilot_flights", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci" do |t|
+  create_table "pilot_flights", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci" do |t|
     t.integer "pilot_id"
     t.integer "flight_id"
     t.integer "sequence_id"
@@ -291,7 +291,7 @@ ActiveRecord::Schema.define(version: 20190828210615) do
     t.index ["sequence_id"], name: "index_pilot_flights_on_sequence_id"
   end
 
-  create_table "region_contests", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci" do |t|
+  create_table "region_contests", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci" do |t|
     t.integer "pc_result_id"
     t.integer "regional_pilot_id"
     t.datetime "created_at"
@@ -301,7 +301,7 @@ ActiveRecord::Schema.define(version: 20190828210615) do
     t.index ["regional_pilot_id"], name: "index_region_contests_on_regional_pilot_id"
   end
 
-  create_table "regional_pilots", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci" do |t|
+  create_table "regional_pilots", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci" do |t|
     t.integer "pilot_id"
     t.string "region", limit: 16, null: false
     t.integer "year"
@@ -316,7 +316,7 @@ ActiveRecord::Schema.define(version: 20190828210615) do
     t.index ["pilot_id"], name: "index_regional_pilots_on_pilot_id"
   end
 
-  create_table "result_accums", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci" do |t|
+  create_table "result_accums", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci" do |t|
     t.integer "result_id"
     t.integer "pc_result_id"
     t.datetime "created_at", null: false
@@ -326,7 +326,7 @@ ActiveRecord::Schema.define(version: 20190828210615) do
     t.index ["result_id"], name: "index_result_accums_on_result_id"
   end
 
-  create_table "result_members", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci" do |t|
+  create_table "result_members", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci" do |t|
     t.integer "member_id"
     t.integer "result_id"
     t.datetime "created_at", null: false
@@ -336,7 +336,7 @@ ActiveRecord::Schema.define(version: 20190828210615) do
     t.index ["result_id"], name: "index_result_members_on_result_id"
   end
 
-  create_table "results", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci" do |t|
+  create_table "results", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci" do |t|
     t.string "type"
     t.integer "year"
     t.integer "category_id"
@@ -354,7 +354,7 @@ ActiveRecord::Schema.define(version: 20190828210615) do
     t.index ["pilot_id"], name: "index_results_on_pilot_id"
   end
 
-  create_table "scores", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci" do |t|
+  create_table "scores", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci" do |t|
     t.integer "pilot_flight_id"
     t.integer "judge_id"
     t.string "values"
@@ -365,7 +365,7 @@ ActiveRecord::Schema.define(version: 20190828210615) do
     t.index ["pilot_flight_id"], name: "index_scores_on_pilot_flight_id"
   end
 
-  create_table "sequences", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci" do |t|
+  create_table "sequences", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci" do |t|
     t.integer "figure_count"
     t.integer "total_k"
     t.integer "mod_3_total"


### PR DESCRIPTION
Closes #115 

The key length of combined make and model columns in the make_models table was greater than 767 bytes. This fixes the length of the two columns to eighty characters (~320 bytes) such that the combined key length is ~640 bytes, safely within limits.

Eighty characters ought to be more than sufficient for an airplane make or model.

The migration is back-dated because the character set migration failed due to this key length
problem.