### PR TITLE
Convert make-model edit wings to radio button

### DIFF
--- a/app/controllers/admin/make_models_controller.rb
+++ b/app/controllers/admin/make_models_controller.rb
@@ -7,6 +7,7 @@ class Admin::MakeModelsController < ApplicationController
 
   def edit
     load_mm
+    @make_model.wings ||= 0 # need non-nil for radio button
     @make_model.curated = true
   end
 

--- a/app/helpers/make_models_helper.rb
+++ b/app/helpers/make_models_helper.rb
@@ -6,4 +6,40 @@ module MakeModelsHelper
   def model_or_unspecified(model)
     model.blank? ? "{no model specified}" : model
   end
+
+  def make_model_wings(mm)
+    number = (mm.wings == nil || mm.wings < 1 || 2 < mm.wings) ? 0 : mm.wings
+    [nil, 'monoplane', 'biplane'][number]
+  end
+
+  def make_model_horsepower(mm)
+    (mm.horsepower && 0 < mm.horsepower) ? "#{mm.horsepower}hp" : nil
+  end
+
+  def make_model_seats(mm)
+    (mm.seats && 0 < mm.seats) ? pluralize(mm.seats, "seat") : nil
+  end
+
+  def make_model_curated(mm)
+    mm.curated ? '👍 ' : ''
+  end
+
+  def make_model_description(mm)
+    [
+      make_model_curated(mm) + make_or_unspecified(mm.make),
+      model_or_unspecified(mm.model),
+      make_model_horsepower(mm),
+      make_model_wings(mm),
+      make_model_seats(mm)
+    ].compact.join(', ')
+  end
+
+  def model_description(mm)
+    [
+      make_model_curated(mm) + model_or_unspecified(mm.model),
+      make_model_horsepower(mm),
+      make_model_wings(mm),
+      make_model_seats(mm)
+    ].compact.join(', ')
+  end
 end

--- a/app/views/admin/make_models/edit.html.erb
+++ b/app/views/admin/make_models/edit.html.erb
@@ -18,7 +18,14 @@
   </div>
   <div class="field">
     <%= f.label(:wings) %>
-    <%= f.number_field(:wings, within: (1..2)) %>
+    <div class="selection">
+      Monoplane
+      <%= f.radio_button(:wings, 1) %>
+      <%= f.radio_button(:wings, 2) %>
+      Biplane
+      (<%= f.radio_button(:wings, 0) %>
+       Undetermined)
+    </div>
   </div>
   <div class="field">
     <%= f.label(:empty_weight_lbs) %>

--- a/app/views/admin/make_models/merge_preview.html.erb
+++ b/app/views/admin/make_models/merge_preview.html.erb
@@ -25,8 +25,8 @@ the selected make and model. It will delete the other make(s) and model(s).
   <% @merge_models.each do |make_model| %>
     <li><%= make_model_description(make_model) %>
       <ul>
-        <% make_model.airplanes.each do |airplane| %>
-          <li><%= "#{airplane.id}: #{airplane.reg}" %>
+        <% make_model.airplanes.collect(&:reg).uniq.sort.each do |reg| %>
+          <li><%= reg.blank? ? '{unspecified registration}' : reg %></li>
         <% end %>
       </ul>
     </li>

--- a/app/views/admin/make_models/merge_preview.html.erb
+++ b/app/views/admin/make_models/merge_preview.html.erb
@@ -6,7 +6,7 @@
       <li>
         <%= radio_button_tag :target, make_model.id,
           make_model.id == @target_id %>
-        <%= "#{make_model.make}, #{make_model.model}" %>
+        <%= make_model_description(make_model) %>
         <%= hidden_field_tag "selected[#{make_model.id}]" %>
       </li>
     <% end %>
@@ -23,7 +23,7 @@ the selected make and model. It will delete the other make(s) and model(s).
 
 <ul class="make-model-airplanes-list">
   <% @merge_models.each do |make_model| %>
-    <li><%= "#{make_model.make}, #{make_model.model}" %>
+    <li><%= make_model_description(make_model) %>
       <ul>
         <% make_model.airplanes.each do |airplane| %>
           <li><%= "#{airplane.id}: #{airplane.reg}" %>

--- a/app/views/make_models/_make_model.html.erb
+++ b/app/views/make_models/_make_model.html.erb
@@ -1,4 +1,3 @@
 <li class="model">
-  <%= '👍 ' if make_model.curated %>
-  <%= model_or_unspecified(make_model.model) %>
+  <%= model_description(make_model) %>
 </li>

--- a/test/controllers/admin/make_model/edit_test.rb
+++ b/test/controllers/admin/make_model/edit_test.rb
@@ -110,10 +110,22 @@ class Admin::MakeModelEditTest < ActionDispatch::IntegrationTest
       )
       assert_equal(1, input.length, "Have seats")
       input = form.xpath(
-        './/input[@type="number" and @name="make_model[wings]" and ' +
-        "@value=\"#{@to_edit.wings}\"]"
+        './/input[@type="radio" and @name="make_model[wings]" and @value="1"]'
       )
-      assert_equal(1, input.length, "Have wings")
+      assert_equal(1, input.length, "Have monoplane")
+      input = form.xpath(
+        './/input[@type="radio" and @name="make_model[wings]" and @value="2"]'
+      )
+      assert_equal(1, input.length, "Have biplane")
+      input = form.xpath(
+        './/input[@type="radio" and @name="make_model[wings]" and not(@value)]'
+      )
+      assert_equal(1, input.length, "Have wings undetermined")
+      input = form.xpath(
+        './/input[@type="radio" and @name="make_model[wings]" and ' +
+        "@value=\"#{@to_edit.wings}\" and @checked]"
+      )
+      assert_equal(1, input.length, "Monoplane or biplane checked")
       input = form.xpath(
         './/input[@type="number" and ' +
         '@name="make_model[empty_weight_lbs]" and ' +

--- a/test/controllers/admin/make_model/edit_test.rb
+++ b/test/controllers/admin/make_model/edit_test.rb
@@ -118,7 +118,7 @@ class Admin::MakeModelEditTest < ActionDispatch::IntegrationTest
       )
       assert_equal(1, input.length, "Have biplane")
       input = form.xpath(
-        './/input[@type="radio" and @name="make_model[wings]" and not(@value)]'
+        './/input[@type="radio" and @name="make_model[wings]" and @value="0"]'
       )
       assert_equal(1, input.length, "Have wings undetermined")
       input = form.xpath(

--- a/test/controllers/admin/make_model/preview_test.rb
+++ b/test/controllers/admin/make_model/preview_test.rb
@@ -68,7 +68,7 @@ class Admin::MakeModelPreviewTest < ActionDispatch::IntegrationTest
       assert_select('ul.make-model-airplanes-list li',
           /#{mm.make}, #{mm.model}/) do
         mm.airplanes.each do |airplane|
-          assert_select('ul li', /#{airplane.id}: #{airplane.reg}/)
+          assert_select('ul li', /#{airplane.reg}/)
         end
       end
     end


### PR DESCRIPTION
Closes #122 
Provides monoplane/biplane/undetermined radio buttons for edit of the "wings" attribute of make and model.
Closes #121 
Eliminates ID values from airplanes in merge preview. For good measure, shows the unique ones and sorts them