### PR TITLE
Repair sequence lookup for free unknown sequences

### DIFF
--- a/spec/fixtures/jasper/jasperFreeUnknown.xml
+++ b/spec/fixtures/jasper/jasperFreeUnknown.xml
@@ -1,0 +1,375 @@
+<?xml version="1.0"?>
+<ContestResults>
+  <Version>
+     <XMLFormat>1.0</XMLFormat>
+     <JaSPer>3.2.41</JaSPer>
+     <Generated>Wed Sep 18 16:23:37 UYT 2019</Generated>
+  </Version>
+  <ContestInfo>
+    <Id>0</Id>
+    <cdbId>693</cdbId>
+    <Contest>U.S. National Aerobatic Championships - Glider - 2019</Contest>
+    <City>Salinas</City>
+    <State>KS</State>
+    <Date>09/21/19</Date>
+    <Director>John Rumbach</Director>
+    <HostChapter>32</HostChapter>
+    <Region>USNationals</Region>
+    <Type>Powered</Type>
+    <Comment></Comment>
+  </ContestInfo>  <Judges>
+    <Category CategoryID="4">
+      <Flight FlightID="1">
+        <Judge JudgeID="0">
+          <Name>
+            <First>Roberto da</First>
+            <Last>Silveira</Last>
+          </Name>
+          <IACNumber>436593</IACNumber>
+          <Assistant>
+            <Name>
+              <First>Marilyn</First>
+              <Last>Dash</Last>
+            </Name>
+            <IACNumber>429794</IACNumber>
+            <Modifier>0</Modifier>
+          </Assistant>
+        </Judge>
+        <Judge JudgeID="1">
+          <Name>
+            <First>Kim</First>
+            <Last>Dahl</Last>
+          </Name>
+          <IACNumber>439030</IACNumber>
+          <Assistant>
+            <Name>
+              <First>Tighe</First>
+              <Last>Daugherty</Last>
+            </Name>
+            <IACNumber>438918</IACNumber>
+            <Modifier>0</Modifier>
+          </Assistant>
+        </Judge>
+        <Judge JudgeID="2">
+          <Name>
+            <First>Nihad</First>
+            <Last>Daidzic</Last>
+          </Name>
+          <IACNumber>430139</IACNumber>
+          <Assistant>
+            <Name>
+              <First>Aaron</First>
+              <Last>Dabney</Last>
+            </Name>
+            <IACNumber>435863</IACNumber>
+            <Modifier>0</Modifier>
+          </Assistant>
+        </Judge>
+        <Judge JudgeID="3">
+          <Name>
+            <First>Michael</First>
+            <Last>Darrah</Last>
+          </Name>
+          <IACNumber>432517</IACNumber>
+          <Assistant>
+            <Name>
+              <First>David Bachler c/o 94</First>
+              <Last>FTS</Last>
+            </Name>
+            <IACNumber>432585</IACNumber>
+            <Modifier>0</Modifier>
+          </Assistant>
+        </Judge>
+      </Flight>
+      <Flight FlightID="2">
+        <Judge JudgeID="0">
+          <Name>
+            <First>Roberto da</First>
+            <Last>Silveira</Last>
+          </Name>
+          <IACNumber>436593</IACNumber>
+          <Assistant>
+            <Name>
+              <First>Marilyn</First>
+              <Last>Dash</Last>
+            </Name>
+            <IACNumber>429794</IACNumber>
+            <Modifier>0</Modifier>
+          </Assistant>
+        </Judge>
+        <Judge JudgeID="1">
+          <Name>
+            <First>Kim</First>
+            <Last>Dahl</Last>
+          </Name>
+          <IACNumber>439030</IACNumber>
+          <Assistant>
+            <Name>
+              <First>Tighe</First>
+              <Last>Daugherty</Last>
+            </Name>
+            <IACNumber>438918</IACNumber>
+            <Modifier>0</Modifier>
+          </Assistant>
+        </Judge>
+        <Judge JudgeID="2">
+          <Name>
+            <First>Nihad</First>
+            <Last>Daidzic</Last>
+          </Name>
+          <IACNumber>430139</IACNumber>
+          <Assistant>
+            <Name>
+              <First>Aaron</First>
+              <Last>Dabney</Last>
+            </Name>
+            <IACNumber>435863</IACNumber>
+            <Modifier>0</Modifier>
+          </Assistant>
+        </Judge>
+        <Judge JudgeID="3">
+          <Name>
+            <First>Michael</First>
+            <Last>Darrah</Last>
+          </Name>
+          <IACNumber>432517</IACNumber>
+          <Assistant>
+            <Name>
+              <First>David Bachler c/o 94</First>
+              <Last>FTS</Last>
+            </Name>
+            <IACNumber>432585</IACNumber>
+            <Modifier>0</Modifier>
+          </Assistant>
+        </Judge>
+      </Flight>
+      <Flight FlightID="3">
+        <Judge JudgeID="0">
+          <Name>
+            <First>Roberto da</First>
+            <Last>Silveira</Last>
+          </Name>
+          <IACNumber>436593</IACNumber>
+          <Assistant>
+            <Name>
+              <First>Marilyn</First>
+              <Last>Dash</Last>
+            </Name>
+            <IACNumber>429794</IACNumber>
+            <Modifier>0</Modifier>
+          </Assistant>
+        </Judge>
+        <Judge JudgeID="1">
+          <Name>
+            <First>Kim</First>
+            <Last>Dahl</Last>
+          </Name>
+          <IACNumber>439030</IACNumber>
+          <Assistant>
+            <Name>
+              <First>Tighe</First>
+              <Last>Daugherty</Last>
+            </Name>
+            <IACNumber>438918</IACNumber>
+            <Modifier>0</Modifier>
+          </Assistant>
+        </Judge>
+        <Judge JudgeID="2">
+          <Name>
+            <First>Nihad</First>
+            <Last>Daidzic</Last>
+          </Name>
+          <IACNumber>430139</IACNumber>
+          <Assistant>
+            <Name>
+              <First>Aaron</First>
+              <Last>Dabney</Last>
+            </Name>
+            <IACNumber>435863</IACNumber>
+            <Modifier>0</Modifier>
+          </Assistant>
+        </Judge>
+        <Judge JudgeID="3">
+          <Name>
+            <First>Michael</First>
+            <Last>Darrah</Last>
+          </Name>
+          <IACNumber>432517</IACNumber>
+          <Assistant>
+            <Name>
+              <First>David Bachler c/o 94</First>
+              <Last>FTS</Last>
+            </Name>
+            <IACNumber>432585</IACNumber>
+            <Modifier>0</Modifier>
+          </Assistant>
+        </Judge>
+      </Flight>
+      <Flight FlightID="4">
+        <Judge JudgeID="0">
+          <Name>
+            <First>Roberto da</First>
+            <Last>Silveira</Last>
+          </Name>
+          <IACNumber>436593</IACNumber>
+          <Assistant>
+            <Name>
+              <First>Marilyn</First>
+              <Last>Dash</Last>
+            </Name>
+            <IACNumber>429794</IACNumber>
+            <Modifier>0</Modifier>
+          </Assistant>
+        </Judge>
+        <Judge JudgeID="1">
+          <Name>
+            <First>Kim</First>
+            <Last>Dahl</Last>
+          </Name>
+          <IACNumber>439030</IACNumber>
+          <Assistant>
+            <Name>
+              <First>Tighe</First>
+              <Last>Daugherty</Last>
+            </Name>
+            <IACNumber>438918</IACNumber>
+            <Modifier>0</Modifier>
+          </Assistant>
+        </Judge>
+        <Judge JudgeID="2">
+          <Name>
+            <First>Nihad</First>
+            <Last>Daidzic</Last>
+          </Name>
+          <IACNumber>430139</IACNumber>
+          <Assistant>
+            <Name>
+              <First>Aaron</First>
+              <Last>Dabney</Last>
+            </Name>
+            <IACNumber>435863</IACNumber>
+            <Modifier>0</Modifier>
+          </Assistant>
+        </Judge>
+        <Judge JudgeID="3">
+          <Name>
+            <First>Michael</First>
+            <Last>Darrah</Last>
+          </Name>
+          <IACNumber>432517</IACNumber>
+          <Assistant>
+            <Name>
+              <First>David Bachler c/o 94</First>
+              <Last>FTS</Last>
+            </Name>
+            <IACNumber>432585</IACNumber>
+            <Modifier>0</Modifier>
+          </Assistant>
+        </Judge>
+      </Flight>
+    </Category>
+  </Judges>
+  <Pilots>
+    <Category CategoryID="4">
+      <Pilot PilotID="1">
+        <IACNumber>430157</IACNumber>
+        <Name>
+          <First>Douglas</First>
+          <Last>Lovell</Last>
+        </Name>
+        <Flights>Known Freestyle Unknown1 Unknown2 </Flights>
+        <Chapter>52</Chapter>
+        <College></College>
+        <FreestyleKs FlightID="2">23 14 21 12 18 16 23 15 11 25 24 21 27 29 21 0 0 0 0 0 25 </FreestyleKs>
+        <FreestyleKs FlightID="3">15 18 32 23 24 34 18 36 28 26 24 33 15 28 21 0 0 0 0 0 25 </FreestyleKs>
+        <FreestyleKs FlightID="4">14 32 12 28 27 25 26 34 31 29 18 22 25 31 33 0 0 0 0 0 25 </FreestyleKs>
+        <SubCategory>NonCollegiate </SubCategory>
+        <Aircraft>
+          <Make>Pitts Special</Make>
+          <Model>S-1T</Model>
+          <NNumber>N627dp</NNumber>
+        </Aircraft>      </Pilot>
+    </Category>
+  </Pilots>
+  <KnownKFactors>
+    <Year>2019</Year>
+    <Category CategoryID="1">7 13 14 10 4 10 0 0 0 0 0 0 0 0 0 0 0 0 0 0 5 </Category>
+    <Category CategoryID="2">10 17 10 14 4 10 10 17 13 14 0 0 0 0 0 0 0 0 0 0 10 </Category>
+    <Category CategoryID="3">21 18 25 13 14 21 19 19 21 14 0 0 0 0 0 0 0 0 0 0 15 </Category>
+    <Category CategoryID="4">40 16 36 40 42 32 33 19 26 0 0 0 0 0 0 0 0 0 0 0 25 </Category>
+    <Category CategoryID="5">40 63 36 35 28 33 53 45 62 0 0 0 0 0 0 0 0 0 0 0 40 </Category>
+    <Category CategoryID="6">40 40 40 40 40 40 40 40 40 40 0 0 0 0 0 0 0 0 0 0 0 </Category>
+  </KnownKFactors>
+  <UnKnownKFactors>
+    <One>
+      <Category CategoryID="3">0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 15 </Category>
+      <Category CategoryID="4">0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 25 </Category>
+      <Category CategoryID="5">0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 40 </Category>
+    </One>
+    <Two>
+      <Category CategoryID="3">0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 15 </Category>
+      <Category CategoryID="4">0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 25 </Category>
+      <Category CategoryID="5">0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 40 </Category>
+    </Two>
+  </UnKnownKFactors>
+  <Scores>
+    <Category CategoryID="4">
+      <Flight FlightID="1">
+        <Pilot PilotID="1">
+          <Judge JudgeID="1">
+            <Figures>7.0 8.0 7.5 8.5 9.0 9.5 8.5 7.5 8.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 9.0 </Figures>
+          </Judge>
+          <Judge JudgeID="2">
+            <Figures>8.0 7.5 7.0 8.5 10.0 9.0 8.5 7.5 7.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 9.0 </Figures>
+          </Judge>
+          <Judge JudgeID="3">
+            <Figures>9.0 7.0 8.5 7.5 8.0 9.0 8.5 9.0 8.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 8.5 </Figures>
+          </Judge>
+          <Penalty>0.0</Penalty>
+        </Pilot>
+      </Flight>
+      <Flight FlightID="2">
+        <Pilot PilotID="1">
+          <Judge JudgeID="1">
+            <Figures>8.0 7.0 9.0 6.0 9.5 8.5 8.0 7.5 9.0 7.0 8.5 7.5 9.5 6.5 9.0 0.0 0.0 0.0 0.0 0.0 9.0 </Figures>
+          </Judge>
+          <Judge JudgeID="2">
+            <Figures>9.0 8.0 7.0 6.0 8.0 7.0 9.0 6.0 8.0 7.0 9.0 6.0 8.0 7.0 9.0 0.0 0.0 0.0 0.0 0.0 6.0 </Figures>
+          </Judge>
+          <Judge JudgeID="3">
+            <Figures>8.0 7.0 9.0 6.0 8.0 9.0 7.0 9.0 7.0 8.0 6.0 8.0 7.0 9.0 8.0 0.0 0.0 0.0 0.0 0.0 6.0 </Figures>
+          </Judge>
+          <Penalty>0.0</Penalty>
+        </Pilot>
+      </Flight>
+      <Flight FlightID="3">
+        <Pilot PilotID="1">
+          <Judge JudgeID="1">
+            <Figures>7.5 8.5 7.0 8.0 7.5 8.5 9.0 8.0 7.0 7.5 8.5 8.0 7.0 9.0 7.5 0.0 0.0 0.0 0.0 0.0 7.5 </Figures>
+          </Judge>
+          <Judge JudgeID="2">
+            <Figures>8.5 8.0 7.0 7.5 7.5 8.5 8.0 9.0 8.5 7.5 7.0 6.5 6.5 7.5 8.5 0.0 0.0 0.0 0.0 0.0 8.5 </Figures>
+          </Judge>
+          <Judge JudgeID="3">
+            <Figures>9.0 9.5 8.5 7.5 7.0 6.5 6.5 7.5 8.5 8.0 9.0 8.5 8.5 8.0 7.0 0.0 0.0 0.0 0.0 0.0 6.5 </Figures>
+          </Judge>
+          <Penalty>0.0</Penalty>
+        </Pilot>
+      </Flight>
+      <Flight FlightID="4">
+        <Pilot PilotID="1">
+          <Judge JudgeID="1">
+            <Figures>8.0 7.0 8.0 9.0 8.5 9.5 7.0 8.0 9.0 9.5 8.5 8.5 8.0 7.5 8.5 0.0 0.0 0.0 0.0 0.0 9.0 </Figures>
+          </Judge>
+          <Judge JudgeID="2">
+            <Figures>8.0 7.5 8.5 8.5 9.0 8.0 7.5 8.5 9.0 9.0 8.0 8.0 8.5 8.5 8.5 0.0 0.0 0.0 0.0 0.0 7.0 </Figures>
+          </Judge>
+          <Judge JudgeID="3">
+            <Figures>8.0 7.0 8.0 8.5 8.5 8.0 9.0 7.0 8.5 9.5 9.0 8.0 8.0 7.5 6.5 0.0 0.0 0.0 0.0 0.0 7.0 </Figures>
+          </Judge>
+          <Penalty>0.0</Penalty>
+        </Pilot>
+      </Flight>
+    </Category>
+  </Scores>
+</ContestResults>

--- a/spec/fixtures/jasper/jasperSequenceTest.xml
+++ b/spec/fixtures/jasper/jasperSequenceTest.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0"?>
+<!--
+  This is for testing flight sequence finding.
+  It is not a complete JaSPer post.
+-->
+<ContestResults>
+  <Version>
+     <XMLFormat>1.0</XMLFormat>
+     <JaSPer>3.2.41</JaSPer>
+     <Generated>Wed Sep 18 16:23:37 UYT 2019</Generated>
+  </Version>
+  <Pilots>
+    <Category CategoryID="2">
+      <Pilot PilotID="2">
+        <FreestyleKs>23 14 21 12 18 16 23 15 11 25 24 21 27 29 21 0 0 0 0 0 25 </FreestyleKs>
+      </Pilot>
+      <Pilot PilotID="3">
+        <FreestyleKs FlightID="2">14 21 12 23 18 16 23 15 11 25 24 21 27 29 21 0 0 0 0 0 25 </FreestyleKs>
+      </Pilot>
+    </Category>
+    <Category CategoryID="4">
+      <Pilot PilotID="1">
+        <FreestyleKs FlightID="2">23 14 21 12 18 16 23 15 11 25 24 21 27 29 21 0 0 0 0 0 25 </FreestyleKs>
+        <FreestyleKs FlightID="3">15 18 32 23 24 34 18 36 28 26 24 33 15 28 21 0 0 0 0 0 25 </FreestyleKs>
+        <FreestyleKs FlightID="4">14 32 12 28 27 25 26 34 31 29 18 22 25 31 33 0 0 0 0 0 25 </FreestyleKs>
+      </Pilot>
+      <Pilot PilotID="2">
+        <FreestyleKs FlightID="2">11 14 21 12 18 16 23 15 23 25 24 21 27 29 21 0 0 0 0 0 25 </FreestyleKs>
+      </Pilot>
+      <Pilot PilotID="3">
+        <FreestyleKs>27 14 21 12 18 16 23 15 23 25 24 21 11 29 21 0 0 0 0 0 25 </FreestyleKs>
+      </Pilot>
+    </Category>
+  </Pilots>
+  <KnownKFactors>
+    <Year>2019</Year>
+    <Category CategoryID="1">7 13 14 10 4 10 0 0 0 0 0 0 0 0 0 0 0 0 0 0 5 </Category>
+    <Category CategoryID="2">10 17 10 14 4 10 10 17 13 14 0 0 0 0 0 0 0 0 0 0 10 </Category>
+    <Category CategoryID="3">21 18 25 13 14 21 19 19 21 14 0 0 0 0 0 0 0 0 0 0 15 </Category>
+    <Category CategoryID="4">40 16 36 40 42 32 33 19 26 0 0 0 0 0 0 0 0 0 0 0 25 </Category>
+    <Category CategoryID="5">40 63 36 35 28 33 53 45 62 0 0 0 0 0 0 0 0 0 0 0 40 </Category>
+    <Category CategoryID="6">40 40 40 40 40 40 40 40 40 40 0 0 0 0 0 0 0 0 0 0 0 </Category>
+  </KnownKFactors>
+  <UnKnownKFactors>
+    <One>
+      <Category CategoryID="3">18 21 25 13 14 21 19 19 21 14 0 0 0 0 0 0 0 0 0 0 15 </Category>
+      <Category CategoryID="4">16 40 36 40 42 32 33 19 26 0 0 0 0 0 0 0 0 0 0 0 25 </Category>
+      <Category CategoryID="5">63 40 36 35 28 33 53 45 62 0 0 0 0 0 0 0 0 0 0 0 40 </Category>
+    </One>
+    <Two>
+      <Category CategoryID="3">25 18 21 13 14 21 19 19 21 14 0 0 0 0 0 0 0 0 0 0 15 </Category>
+      <Category CategoryID="4">36 16 40 40 42 32 33 19 26 0 0 0 0 0 0 0 0 0 0 0 25 </Category>
+      <Category CategoryID="5">36 63 40 35 28 33 53 45 62 0 0 0 0 0 0 0 0 0 0 0 40 </Category>
+    </Two>
+  </UnKnownKFactors>
+</ContestResults>

--- a/test/services/jasper/parse/sequence_test.rb
+++ b/test/services/jasper/parse/sequence_test.rb
@@ -1,0 +1,93 @@
+require 'test_helper'
+require_relative '../contest_data'
+
+module Jasper
+  class ParseSequenceTest < ActiveSupport::TestCase
+    include ContestData
+
+    setup do
+      @jasper = jasper_parse_from_test_data_file('jasperSequenceTest.xml')
+      @known_ks = ['',
+        '7 13 14 10 4 10 0 0 0 0 0 0 0 0 0 0 0 0 0 0 5',
+        '10 17 10 14 4 10 10 17 13 14 0 0 0 0 0 0 0 0 0 0 10',
+        '21 18 25 13 14 21 19 19 21 14 0 0 0 0 0 0 0 0 0 0 15',
+        '40 16 36 40 42 32 33 19 26 0 0 0 0 0 0 0 0 0 0 0 25',
+        '40 63 36 35 28 33 53 45 62 0 0 0 0 0 0 0 0 0 0 0 40',
+        '40 40 40 40 40 40 40 40 40 40 0 0 0 0 0 0 0 0 0 0 0'
+      ]
+    end
+
+    test 'always finds primary known' do
+      assert_equal(@known_ks[1], @jasper.k_values_for(1, 1, 1).strip)
+      assert_equal(@known_ks[1], @jasper.k_values_for(1, 1, 3).strip)
+      assert_equal(@known_ks[1], @jasper.k_values_for(1, 2, 1).strip)
+      assert_equal(@known_ks[1], @jasper.k_values_for(1, 3, 1).strip)
+      assert_equal(@known_ks[1], @jasper.k_values_for(1, 4, 1).strip)
+    end
+
+    test 'always finds category knowns' do
+      (2...6).each do |cat|
+        assert_equal(@known_ks[cat], @jasper.k_values_for(cat, 1, 1).strip)
+      end
+    end
+
+    test 'finds sportsman known when no pilot free' do
+      assert_equal(@known_ks[2], @jasper.k_values_for(2, 2, 1).strip)
+      assert_equal(@known_ks[2], @jasper.k_values_for(2, 3, 1).strip)
+    end
+
+    test 'finds sportsman pilot specified free' do
+      free_ks = '23 14 21 12 18 16 23 15 11 25 24 21 27 29 21 0 0 0 0 0 25'
+      assert_equal(free_ks, @jasper.k_values_for(2, 2, 2).strip)
+      assert_equal(free_ks, @jasper.k_values_for(2, 3, 2).strip)
+    end
+
+    test 'finds sportsman pilot flight identified free' do
+      free_ks = '14 21 12 23 18 16 23 15 11 25 24 21 27 29 21 0 0 0 0 0 25'
+      assert_equal(free_ks, @jasper.k_values_for(2, 2, 3).strip)
+      assert_equal(free_ks, @jasper.k_values_for(2, 3, 3).strip)
+    end
+
+    test 'finds advanced flight identified free' do
+      jCat = 4; jFlt = 2; jPilot = 2;
+      assert_equal(
+        '11 14 21 12 18 16 23 15 23 25 24 21 27 29 21 0 0 0 0 0 25',
+        @jasper.k_values_for(jCat, jFlt, jPilot).strip)
+    end
+
+    test 'finds advanced flight unidentified free' do
+      jCat = 4; jFlt = 2; jPilot = 3;
+      assert_equal(
+        '27 14 21 12 18 16 23 15 23 25 24 21 11 29 21 0 0 0 0 0 25',
+        @jasper.k_values_for(jCat, jFlt, jPilot).strip)
+    end
+
+    test 'finds advanced first unknown' do
+      jCat = 4; jFlt = 3; jPilot = 2;
+      assert_equal(
+        '16 40 36 40 42 32 33 19 26 0 0 0 0 0 0 0 0 0 0 0 25',
+        @jasper.k_values_for(jCat, jFlt, jPilot).strip)
+    end
+
+    test 'finds advanced second unknown' do
+      jCat = 4; jFlt = 4; jPilot = 2;
+      assert_equal(
+        '36 16 40 40 42 32 33 19 26 0 0 0 0 0 0 0 0 0 0 0 25',
+        @jasper.k_values_for(jCat, jFlt, jPilot).strip)
+    end
+
+    test 'finds advanced flight identified free unknown' do
+      jCat = 4; jFlt = 3; jPilot = 1;
+      assert_equal(
+        '15 18 32 23 24 34 18 36 28 26 24 33 15 28 21 0 0 0 0 0 25',
+        @jasper.k_values_for(jCat, jFlt, jPilot).strip)
+    end
+
+    test 'finds advanced flight identified free unknown two' do
+      jCat = 4; jFlt = 4; jPilot = 1;
+      assert_equal(
+        '14 32 12 28 27 25 26 34 31 29 18 22 25 31 33 0 0 0 0 0 25',
+        @jasper.k_values_for(jCat, jFlt, jPilot).strip)
+    end
+  end
+end

--- a/test/services/jasper/unknown_k_test.rb
+++ b/test/services/jasper/unknown_k_test.rb
@@ -1,0 +1,65 @@
+require 'test_helper'
+require_relative 'contest_data'
+
+module Jasper
+  class UnknownKTest < ActiveSupport::TestCase
+    include ContestData
+
+    setup do
+      jasper = jasper_parse_from_test_data_file('jasperFreeUnknown.xml')
+      j2d = Jasper::JasperToDB.new
+      @contest = j2d.process_contest(jasper)
+    end
+
+    test 'captures free sequence' do
+      cat = Category.find_for_cat_aircat('Advanced', 'P')
+      flight = @contest.flights.where(sequence: 2, category_id: cat.id).first
+      refute_nil(flight)
+      pilot = Member.where(:family_name => 'Lovell').first
+      refute_nil(pilot)
+      pilot_flight = flight.pilot_flights.where(:pilot_id => pilot).first
+      refute_nil(pilot_flight)
+      sequence = pilot_flight.sequence
+      refute_nil(sequence)
+      assert_equal(16, sequence.figure_count)
+      assert_equal(325, sequence.total_k)
+      assert_equal(
+        [23, 14, 21, 12, 18, 16, 23, 15, 11, 25, 24, 21, 27, 29, 21, 25],
+        sequence.k_values)
+    end
+
+    test 'captures free unknown sequence' do
+      cat = Category.find_for_cat_aircat('Advanced', 'P')
+      flight = @contest.flights.where(sequence: 3, category_id: cat.id).first
+      refute_nil(flight)
+      pilot = Member.where(:family_name => 'Lovell').first
+      refute_nil(pilot)
+      pilot_flight = flight.pilot_flights.where(:pilot_id => pilot).first
+      refute_nil(pilot_flight)
+      sequence = pilot_flight.sequence
+      refute_nil(sequence)
+      assert_equal(16, sequence.figure_count)
+      assert_equal(400, sequence.total_k)
+      assert_equal(
+        [15, 18, 32, 23, 24, 34, 18, 36, 28, 26, 24, 33, 15, 28, 21, 25],
+        sequence.k_values)
+    end
+
+    test 'captures second free unknown sequence' do
+      cat = Category.find_for_cat_aircat('Advanced', 'P')
+      flight = @contest.flights.where(sequence: 4, category_id: cat.id).first
+      refute_nil(flight)
+      pilot = Member.where(:family_name => 'Lovell').first
+      refute_nil(pilot)
+      pilot_flight = flight.pilot_flights.where(:pilot_id => pilot).first
+      refute_nil(pilot_flight)
+      sequence = pilot_flight.sequence
+      refute_nil(sequence)
+      assert_equal(16, sequence.figure_count)
+      assert_equal(412, sequence.total_k)
+      assert_equal(
+        [14, 32, 12, 28, 27, 25, 26, 34, 31, 29, 18, 22, 25, 31, 33, 25],
+        sequence.k_values)
+    end
+  end
+end


### PR DESCRIPTION
Closes #126 

The logic for parsing the potential differences based on category and flight is much more complicated now.

If the FlightId was always present for FreeStyleKs, there would be less logic; however, older posts did not have a FlightId (because prior, it was always FlightId="2").

If the KnownKFactors and UnKnownKFactors were coded with FlightId, there would be less logic.

Primary and Sportsman have business logic around either no free or optional free.