### PR TITLE
Add synthesized category by copy of flights

### DIFF
--- a/app/models/flight_m/copy_to_category.rb
+++ b/app/models/flight_m/copy_to_category.rb
@@ -1,0 +1,34 @@
+module FlightM
+  module CopyToCategory
+    def copy_to_category(category)
+      new_attrs = self.attributes
+      new_attrs.delete('id')
+      new_attrs.delete('category_id')
+      new_attrs['category_id'] = category.id
+      flight = Flight.find_by(contest_id: self.contest_id,
+        name: self.name, category_id: category.id)
+      if (flight)
+        flight.update!(new_attrs)
+      else
+        new_attrs['category_id'] = category.id
+        flight = Flight.create!(new_attrs)
+      end
+      copy_pilot_flights_to(flight)
+      flight
+    end
+
+    def copy_pilot_flights_to(flight)
+      new_pilots = self.pilot_flights.collect(&:pilot_id)
+      prior_pilots = flight.pilot_flights.collect(&:pilot_id)
+      flight.pilot_flights.where(
+        pilot_id: prior_pilots - new_pilots
+      ).each do |pf|
+        flight.pilot_flights.delete(pf)
+      end
+      self.pilot_flights.each do |pf|
+        pf.extend(PilotFlightM::CopyToFlight)
+        pf.copy_to_flight(flight)
+      end
+    end
+  end
+end

--- a/app/models/pilot_flight_m/copy_to_flight.rb
+++ b/app/models/pilot_flight_m/copy_to_flight.rb
@@ -1,0 +1,29 @@
+module PilotFlightM
+  module CopyToFlight
+    def copy_to_flight(flight)
+      new_attrs = self.attributes
+      new_attrs.delete('id')
+      new_attrs.delete('flight_id')
+      pf = flight.pilot_flights.find_by(pilot_id: self.pilot_id)
+      if (pf)
+        pf.update!(new_attrs)
+      else
+        pf = flight.pilot_flights.create!(new_attrs)
+      end
+      copy_grades_to(pf)
+      pf
+    end
+
+    def copy_grades_to(pf)
+      new_judges = self.scores.collect(&:judge_id)
+      prior_judges = pf.scores.collect(&:judge_id)
+      pf.scores.where(judge_id: prior_judges - new_judges).each do |s|
+        pf.scores.delete(s)
+      end
+      self.scores.each do |s|
+        s.extend(ScoreM::CopyToPilotFlight)
+        s.copy_to_pilot_flight(pf)
+      end
+    end
+  end
+end

--- a/app/models/score_m/copy_to_pilot_flight.rb
+++ b/app/models/score_m/copy_to_pilot_flight.rb
@@ -1,0 +1,16 @@
+module ScoreM
+  module CopyToPilotFlight
+    def copy_to_pilot_flight(pf)
+      new_attrs = self.attributes
+      new_attrs.delete('id')
+      new_attrs.delete('pilot_flight_id')
+      scores = pf.scores.find_by(judge_id: self.judge_id)
+      if (scores)
+        scores.update(new_attrs)
+      else
+        scores = pf.scores.create(new_attrs)
+      end
+      scores
+    end
+  end
+end

--- a/app/models/synthetic_category.rb
+++ b/app/models/synthetic_category.rb
@@ -3,4 +3,20 @@ class SyntheticCategory < ApplicationRecord
   belongs_to :regular_category, class_name: 'Category'
   serialize :regular_category_flights
   serialize :synthetic_category_flights
+
+  def find_or_create
+    last_seq = Category.pluck(:sequence).max
+    begin
+      cat = Category.find_or_create_by(
+        category: self.synthetic_category_name,
+        aircat: regular_category.aircat,
+      ) do |c|
+        c.sequence = last_seq + 1
+        c.name = self.synthetic_category_description
+        c.synthetic = true
+      end
+    rescue ActiveRecord::RecordNotUnique
+      retry
+    end
+  end
 end

--- a/app/models/synthetic_category.rb
+++ b/app/models/synthetic_category.rb
@@ -1,0 +1,6 @@
+class SyntheticCategory < ApplicationRecord
+  belongs_to :contest
+  belongs_to :regular_category, class_name: 'Category'
+  serialize :regular_category_flights
+  serialize :synthetic_category_flights
+end

--- a/app/services/category_synthesis_service.rb
+++ b/app/services/category_synthesis_service.rb
@@ -1,0 +1,25 @@
+class CategorySynthesisService
+  def initialize(synthetic_category)
+    @sc = synthetic_category
+  end
+
+  def synthesize_category
+    reg_cat = @sc.regular_category
+    syn_cat = @sc.find_or_create
+    reg_flights = Flight.where(contest: @sc.contest, category: reg_cat)
+    @sc.synthetic_category_flights.each do |name|
+      reg_flight = Flight.find_by(
+        contest: @sc.contest, category: reg_cat, name: name
+      )
+      reg_flight.extend(FlightM::CopyToCategory)
+      reg_flight.copy_to_category(syn_cat)
+    end
+    non_reg_names =
+      @sc.synthetic_category_flights - @sc.regular_category_flights
+    Flight.where(
+      contest: @sc.contest, category: reg_cat, name: non_reg_names
+    ).each do |flight|
+      flight.destroy!
+    end
+  end
+end

--- a/app/services/category_synthesis_service.rb
+++ b/app/services/category_synthesis_service.rb
@@ -1,25 +1,28 @@
 class CategorySynthesisService
-  def initialize(synthetic_category)
-    @sc = synthetic_category
-  end
-
-  def synthesize_category
-    reg_cat = @sc.regular_category
-    syn_cat = @sc.find_or_create
-    reg_flights = Flight.where(contest: @sc.contest, category: reg_cat)
-    @sc.synthetic_category_flights.each do |name|
+  def self.synthesize_category(synthetic_category)
+    sc = synthetic_category # shorthand
+    reg_cat = sc.regular_category
+    syn_cat = sc.find_or_create
+    reg_flights = Flight.where(contest: sc.contest, category: reg_cat)
+    sc.synthetic_category_flights.each do |name|
       reg_flight = Flight.find_by(
-        contest: @sc.contest, category: reg_cat, name: name
+        contest: sc.contest, category: reg_cat, name: name
       )
       reg_flight.extend(FlightM::CopyToCategory)
       reg_flight.copy_to_category(syn_cat)
     end
     non_reg_names =
-      @sc.synthetic_category_flights - @sc.regular_category_flights
+      sc.synthetic_category_flights - sc.regular_category_flights
     Flight.where(
-      contest: @sc.contest, category: reg_cat, name: non_reg_names
+      contest: sc.contest, category: reg_cat, name: non_reg_names
     ).each do |flight|
       flight.destroy!
+    end
+  end
+
+  def self.synthesize_categories(contest)
+    SyntheticCategory.where(contest: contest).each do |sc|
+      self.synthesize_category(sc)
     end
   end
 end

--- a/app/services/jobs/compute_flights_job.rb
+++ b/app/services/jobs/compute_flights_job.rb
@@ -8,6 +8,7 @@ class ComputeFlightsJob < Struct.new(:contest)
   def perform
     @contest = contest
     say "Computing flights for #{@contest.year_name}"
+    CategorySynthesisService.synthesize_categories(@contest)
     computer = ContestComputer.new(@contest)
     computer.compute_flights
   end

--- a/db/migrate/20190919151543_create_synthetic_categories.rb
+++ b/db/migrate/20190919151543_create_synthetic_categories.rb
@@ -1,0 +1,16 @@
+class CreateSyntheticCategories < ActiveRecord::Migration[5.1]
+  def change
+    create_table :synthetic_categories, id: :integer do |t|
+      t.references :contest, type: :integer, foreign_key: true
+      t.references :regular_category, type: :integer
+      t.text :regular_category_flights
+      t.string :synthetic_category_name
+      t.string :synthetic_category_description
+      t.text :synthetic_category_flights
+
+      t.foreign_key(:categories, column: :regular_category_id,
+        on_delete: :cascade, on_update: :cascade)
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20190921120240_add_synthetic_flag_to_category.rb
+++ b/db/migrate/20190921120240_add_synthetic_flag_to_category.rb
@@ -1,0 +1,5 @@
+class AddSyntheticFlagToCategory < ActiveRecord::Migration[5.1]
+  def change
+    add_column :categories, :synthetic, :boolean, null: false, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,9 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190905130441) do
+ActiveRecord::Schema.define(version: 20190919151543) do
 
-  create_table "airplanes", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci" do |t|
+  create_table "airplanes", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci" do |t|
     t.string "reg"
     t.datetime "created_at"
     t.datetime "updated_at"
@@ -20,7 +20,7 @@ ActiveRecord::Schema.define(version: 20190905130441) do
     t.index ["id"], name: "index_airplanes_on_id"
   end
 
-  create_table "categories", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci" do |t|
+  create_table "categories", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci" do |t|
     t.integer "sequence", null: false
     t.string "category", limit: 16, null: false
     t.string "aircat", limit: 1, null: false
@@ -30,7 +30,7 @@ ActiveRecord::Schema.define(version: 20190905130441) do
     t.index ["id"], name: "index_categories_on_id"
   end
 
-  create_table "contests", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci" do |t|
+  create_table "contests", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci" do |t|
     t.string "name", limit: 48
     t.string "city", limit: 24
     t.string "state", limit: 2
@@ -43,7 +43,7 @@ ActiveRecord::Schema.define(version: 20190905130441) do
     t.index ["id"], name: "index_contests_on_id"
   end
 
-  create_table "data_posts", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci" do |t|
+  create_table "data_posts", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci" do |t|
     t.integer "contest_id"
     t.boolean "is_integrated", default: false
     t.boolean "has_error", default: false
@@ -55,7 +55,7 @@ ActiveRecord::Schema.define(version: 20190905130441) do
     t.index ["id"], name: "index_data_posts_on_id"
   end
 
-  create_table "delayed_jobs", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci" do |t|
+  create_table "delayed_jobs", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci" do |t|
     t.integer "priority", default: 0
     t.integer "attempts", default: 0
     t.text "handler", limit: 16777215
@@ -70,7 +70,7 @@ ActiveRecord::Schema.define(version: 20190905130441) do
     t.index ["priority", "run_at"], name: "delayed_jobs_priority"
   end
 
-  create_table "failures", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci" do |t|
+  create_table "failures", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci" do |t|
     t.string "step", limit: 16
     t.integer "contest_id"
     t.integer "manny_id"
@@ -84,7 +84,7 @@ ActiveRecord::Schema.define(version: 20190905130441) do
     t.index ["manny_id"], name: "index_failures_on_manny_id"
   end
 
-  create_table "flights", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci" do |t|
+  create_table "flights", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci" do |t|
     t.integer "contest_id", null: false
     t.string "name", limit: 16, null: false
     t.integer "sequence", null: false
@@ -100,7 +100,7 @@ ActiveRecord::Schema.define(version: 20190905130441) do
     t.index ["id"], name: "index_flights_on_id"
   end
 
-  create_table "jc_results", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci" do |t|
+  create_table "jc_results", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci" do |t|
     t.integer "judge_id", null: false
     t.integer "pilot_count"
     t.decimal "sigma_ri_delta", precision: 11, scale: 5
@@ -127,7 +127,7 @@ ActiveRecord::Schema.define(version: 20190905130441) do
     t.index ["judge_id"], name: "index_jc_results_on_judge_id"
   end
 
-  create_table "jf_results", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci" do |t|
+  create_table "jf_results", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci" do |t|
     t.integer "judge_id"
     t.integer "pilot_count"
     t.decimal "sigma_ri_delta", precision: 10, scale: 5
@@ -152,7 +152,7 @@ ActiveRecord::Schema.define(version: 20190905130441) do
     t.index ["judge_id"], name: "index_jf_results_on_judge_id"
   end
 
-  create_table "judges", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci" do |t|
+  create_table "judges", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci" do |t|
     t.integer "judge_id"
     t.integer "assist_id"
     t.datetime "created_at"
@@ -162,7 +162,7 @@ ActiveRecord::Schema.define(version: 20190905130441) do
     t.index ["judge_id"], name: "index_judges_on_judge_id"
   end
 
-  create_table "jy_results", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci" do |t|
+  create_table "jy_results", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci" do |t|
     t.integer "judge_id"
     t.integer "category_id"
     t.integer "year"
@@ -188,7 +188,7 @@ ActiveRecord::Schema.define(version: 20190905130441) do
     t.index ["judge_id"], name: "index_jy_results_on_judge_id"
   end
 
-  create_table "make_models", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci" do |t|
+  create_table "make_models", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci" do |t|
     t.string "make", limit: 80
     t.string "model", limit: 80
     t.integer "empty_weight_lbs", limit: 2
@@ -203,7 +203,7 @@ ActiveRecord::Schema.define(version: 20190905130441) do
     t.index ["model"], name: "index_make_models_on_model"
   end
 
-  create_table "manny_synches", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci" do |t|
+  create_table "manny_synches", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci" do |t|
     t.integer "contest_id"
     t.integer "manny_number"
     t.datetime "synch_date"
@@ -212,7 +212,7 @@ ActiveRecord::Schema.define(version: 20190905130441) do
     t.index ["contest_id"], name: "index_manny_synches_on_contest_id"
   end
 
-  create_table "members", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci" do |t|
+  create_table "members", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci" do |t|
     t.integer "iac_id"
     t.string "given_name", limit: 40
     t.string "family_name", limit: 40
@@ -222,7 +222,7 @@ ActiveRecord::Schema.define(version: 20190905130441) do
     t.index ["id"], name: "index_members_on_id"
   end
 
-  create_table "pc_results", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci" do |t|
+  create_table "pc_results", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci" do |t|
     t.integer "pilot_id", null: false
     t.decimal "category_value", precision: 8, scale: 2
     t.integer "category_rank"
@@ -240,7 +240,7 @@ ActiveRecord::Schema.define(version: 20190905130441) do
     t.index ["pilot_id"], name: "index_pc_results_on_pilot_id"
   end
 
-  create_table "pf_results", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci" do |t|
+  create_table "pf_results", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci" do |t|
     t.integer "pilot_flight_id", null: false
     t.decimal "flight_value", precision: 7, scale: 2
     t.decimal "adj_flight_value", precision: 7, scale: 2
@@ -256,7 +256,7 @@ ActiveRecord::Schema.define(version: 20190905130441) do
     t.index ["pilot_flight_id"], name: "index_pf_results_on_pilot_flight_id"
   end
 
-  create_table "pfj_results", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci" do |t|
+  create_table "pfj_results", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci" do |t|
     t.integer "pilot_flight_id", null: false
     t.integer "judge_id", null: false
     t.string "computed_values"
@@ -273,7 +273,7 @@ ActiveRecord::Schema.define(version: 20190905130441) do
     t.index ["pilot_flight_id"], name: "index_pfj_results_on_pilot_flight_id"
   end
 
-  create_table "pilot_flights", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci" do |t|
+  create_table "pilot_flights", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci" do |t|
     t.integer "pilot_id"
     t.integer "flight_id"
     t.integer "sequence_id"
@@ -290,7 +290,7 @@ ActiveRecord::Schema.define(version: 20190905130441) do
     t.index ["sequence_id"], name: "index_pilot_flights_on_sequence_id"
   end
 
-  create_table "region_contests", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci" do |t|
+  create_table "region_contests", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci" do |t|
     t.integer "pc_result_id"
     t.integer "regional_pilot_id"
     t.datetime "created_at"
@@ -300,7 +300,7 @@ ActiveRecord::Schema.define(version: 20190905130441) do
     t.index ["regional_pilot_id"], name: "index_region_contests_on_regional_pilot_id"
   end
 
-  create_table "regional_pilots", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci" do |t|
+  create_table "regional_pilots", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci" do |t|
     t.integer "pilot_id"
     t.string "region", limit: 16, null: false
     t.integer "year"
@@ -315,7 +315,7 @@ ActiveRecord::Schema.define(version: 20190905130441) do
     t.index ["pilot_id"], name: "index_regional_pilots_on_pilot_id"
   end
 
-  create_table "result_accums", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci" do |t|
+  create_table "result_accums", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci" do |t|
     t.integer "result_id"
     t.integer "pc_result_id"
     t.datetime "created_at", null: false
@@ -325,7 +325,7 @@ ActiveRecord::Schema.define(version: 20190905130441) do
     t.index ["result_id"], name: "index_result_accums_on_result_id"
   end
 
-  create_table "result_members", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci" do |t|
+  create_table "result_members", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci" do |t|
     t.integer "member_id"
     t.integer "result_id"
     t.datetime "created_at", null: false
@@ -335,7 +335,7 @@ ActiveRecord::Schema.define(version: 20190905130441) do
     t.index ["result_id"], name: "index_result_members_on_result_id"
   end
 
-  create_table "results", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci" do |t|
+  create_table "results", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci" do |t|
     t.string "type"
     t.integer "year"
     t.integer "category_id"
@@ -353,7 +353,7 @@ ActiveRecord::Schema.define(version: 20190905130441) do
     t.index ["pilot_id"], name: "index_results_on_pilot_id"
   end
 
-  create_table "scores", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci" do |t|
+  create_table "scores", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci" do |t|
     t.integer "pilot_flight_id"
     t.integer "judge_id"
     t.string "values"
@@ -364,7 +364,7 @@ ActiveRecord::Schema.define(version: 20190905130441) do
     t.index ["pilot_flight_id"], name: "index_scores_on_pilot_flight_id"
   end
 
-  create_table "sequences", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci" do |t|
+  create_table "sequences", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci" do |t|
     t.integer "figure_count"
     t.integer "total_k"
     t.integer "mod_3_total"
@@ -375,11 +375,19 @@ ActiveRecord::Schema.define(version: 20190905130441) do
     t.index ["id"], name: "index_sequences_on_id"
   end
 
-  create_table "writers", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
-    t.string "name"
+  create_table "synthetic_categories", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci" do |t|
+    t.integer "contest_id"
+    t.integer "regular_category_id"
+    t.text "regular_category_flights"
+    t.string "synthetic_category_name"
+    t.string "synthetic_category_description"
+    t.text "synthetic_category_flights"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["id"], name: "index_writers_on_id"
+    t.index ["contest_id"], name: "index_synthetic_categories_on_contest_id"
+    t.index ["regular_category_id"], name: "index_synthetic_categories_on_regular_category_id"
   end
 
+  add_foreign_key "synthetic_categories", "categories", column: "regular_category_id", on_update: :cascade, on_delete: :cascade
+  add_foreign_key "synthetic_categories", "contests"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190919151543) do
+ActiveRecord::Schema.define(version: 20190921120240) do
 
   create_table "airplanes", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci" do |t|
     t.string "reg"
@@ -27,6 +27,7 @@ ActiveRecord::Schema.define(version: 20190919151543) do
     t.string "name", limit: 32, null: false
     t.datetime "created_at"
     t.datetime "updated_at"
+    t.boolean "synthetic", default: false, null: false
     t.index ["id"], name: "index_categories_on_id"
   end
 

--- a/spec/factories/model.rb
+++ b/spec/factories/model.rb
@@ -107,10 +107,14 @@ FactoryBot.define do
       aircat { 'P' }
     end
     initialize_with do
-      factory_cat = Category.where(:category => category, :aircat => aircat).first
+      factory_cat = Category.where(
+        :category => category, :aircat => aircat
+      ).first
       unless factory_cat
-        sequence = Category.select('MAX sequence').first.sequence + 1
-        factory_cat = Category.create(:category => cat, :aircat => aircat, :sequence => sequence)
+        seq = Category.select('MAX(sequence)').first.send(:sequence) + 1
+        factory_cat = Category.create(
+          category: cat, aircat: aircat, sequence: seq
+        )
       end
       factory_cat
     end

--- a/spec/factories/synthetic_categories.rb
+++ b/spec/factories/synthetic_categories.rb
@@ -1,0 +1,24 @@
+FactoryBot.define do
+  factory :synthetic_category do
+    transient do
+      regular_category_name { 'Advanced' }
+      regular_category_aircat { 'P' }
+      flight_names { ['Known', 'Free', 'Unknown I'] }
+      extra_flight_names { ['Unknown II'] }
+    end
+    initialize_with do
+      contest = create(:contest)
+      regular_category = create(:category,
+        category: regular_category_name, aircat: regular_category_aircat)
+      syncat = SyntheticCategory.new(contest: contest,
+        regular_category: regular_category)
+      syncat.regular_category_flights = flight_names
+      syncat.synthetic_category_name =
+        [regular_category_name, 'team'].join(' ')
+      syncat.synthetic_category_description =
+        [regular_category_name, 'team'].join(' ').camelcase
+      syncat.synthetic_category_flights = flight_names + extra_flight_names
+      syncat
+    end
+  end
+end

--- a/test/models/flight/copy_to_category_test.rb
+++ b/test/models/flight/copy_to_category_test.rb
@@ -1,0 +1,57 @@
+require 'test_helper'
+
+class Flight::CopyToCategoryTest < ActiveSupport::TestCase
+  setup do
+    @existing = create(:flight)
+    @existing.extend(FlightM::CopyToCategory)
+    @category = Category.create(category: 'advanced team', aircat: 'P',
+      name: 'U.S. Advanced Aerobatic Team', sequence: 12)
+  end
+
+  test 'copies existing to new on different category' do
+    copied = @existing.copy_to_category(@category)
+    refute_equal(@existing.id, copied.id)
+    assert_equal(@category.id, copied.category_id)
+    assert_equal(@existing.contest_id, copied.contest_id)
+    assert_equal(@existing.name, copied.name)
+    assert_equal(@existing.sequence, copied.sequence)
+    assert_equal(@existing.chief_id, copied.chief_id)
+    assert_equal(@existing.assist_id, copied.assist_id)
+  end
+
+  test 'does not create duplicate on category' do
+    copied = @existing.copy_to_category(@category)
+    copied_too = @existing.copy_to_category(@category)
+    assert_equal(copied, copied_too)
+  end
+
+  test 'copies the pilot_flights' do
+    create_list(:pilot_flight, 7, flight: @existing)
+    copied = @existing.copy_to_category(@category)
+    refute_equal(@existing.id, copied.id)
+    assert_equal(@existing.pilot_flights.count, copied.pilot_flights.count)
+    e_pilots = @existing.pilot_flights.collect(&:pilot_id).sort
+    c_pilots = copied.pilot_flights.collect(&:pilot_id).sort
+    assert_equal(e_pilots, c_pilots)
+    e_airplanes = @existing.pilot_flights.collect(&:airplane_id).sort
+    c_airplanes = copied.pilot_flights.collect(&:airplane_id).sort
+    assert_equal(e_airplanes, c_airplanes)
+  end
+
+  test 'updates the pilot_flights' do
+    create_list(:pilot_flight, 7, flight: @existing)
+    @existing.copy_to_category(@category)
+    removed = @existing.pilot_flights.first.destroy
+    changed = @existing.reload.pilot_flights.first
+    changed.update!(penalty_total: changed.penalty_total + 20)
+    inserted = create(:pilot_flight, flight: @existing)
+
+    copied = @existing.copy_to_category(@category)
+
+    pilot_ids = copied.pilot_flights.collect(&:pilot_id)
+    refute_includes(pilot_ids, removed.pilot_id)
+    assert_includes(pilot_ids, inserted.pilot_id)
+    changed_copy = copied.pilot_flights.find_by(pilot_id: changed.pilot_id)
+    assert_equal(changed.penalty_total, changed_copy.penalty_total)
+  end
+end

--- a/test/models/pilot_flight/copy_to_flight_test.rb
+++ b/test/models/pilot_flight/copy_to_flight_test.rb
@@ -1,0 +1,57 @@
+require 'test_helper'
+
+class PilotFlight::CopyToFlightTest < ActiveSupport::TestCase
+  setup do
+    @existing = create(:pilot_flight)
+    @existing.extend(PilotFlightM::CopyToFlight)
+    @flight = create :flight
+  end
+
+  test 'copies existing to new on different flight' do
+    copied = @existing.copy_to_flight(@flight)
+    refute_equal(@existing.id, copied.id)
+    assert_equal(@flight.id, copied.flight_id)
+    assert_equal(@existing.pilot_id, copied.pilot_id)
+    assert_equal(@existing.sequence_id, copied.sequence_id)
+    assert_equal(@existing.airplane_id, copied.airplane_id)
+    assert_equal(@existing.chapter, copied.chapter)
+    assert_equal(@existing.penalty_total, copied.penalty_total)
+    assert_equal(@existing.hors_concours, copied.hors_concours)
+  end
+
+  test 'does not create duplicate on flight' do
+    copied = @existing.copy_to_flight(@flight)
+    copied_too = @existing.copy_to_flight(@flight)
+    assert_equal(copied, copied_too)
+  end
+
+  test 'copies the scores' do
+    create_list(:score, 7, pilot_flight: @existing)
+    copied = @existing.copy_to_flight(@flight)
+    refute_equal(@existing.id, copied.id)
+    assert_equal(@existing.scores.count, copied.scores.count)
+    e_judges = @existing.scores.collect(&:judge_id).sort
+    c_judges = copied.scores.collect(&:judge_id).sort
+    assert_equal(e_judges, c_judges)
+    e_grades = @existing.scores.collect(&:values).flatten.sort
+    c_grades = copied.scores.collect(&:values).flatten.sort
+    assert_equal(e_grades, c_grades)
+  end
+
+  test 'updates the scores' do
+    create_list(:score, 7, pilot_flight: @existing)
+    @existing.copy_to_flight(@flight)
+    removed = @existing.scores.first.destroy
+    changed = @existing.reload.scores.first
+    changed.update!(values: changed.values.map{ |v| v - 5 })
+    inserted = create(:score, pilot_flight: @existing)
+
+    copied = @existing.copy_to_flight(@flight)
+
+    judge_ids = copied.scores.collect(&:judge_id)
+    refute_includes(judge_ids, removed.judge_id)
+    assert_includes(judge_ids, inserted.judge_id)
+    changed_copy = copied.scores.find_by(judge_id: changed.judge_id)
+    assert_equal(changed.values, changed_copy.values)
+  end
+end

--- a/test/models/score/copy_to_pilot_flight_test.rb
+++ b/test/models/score/copy_to_pilot_flight_test.rb
@@ -1,0 +1,25 @@
+require 'test_helper'
+
+class Score::CopyToPilotFlightTest < ActiveSupport::TestCase
+  setup do
+    @existing = create(:score)
+    @existing.extend(ScoreM::CopyToPilotFlight)
+    flight = create(:flight, contest: @existing.contest, category:
+      @existing.flight.category)
+    @pf = create(:pilot_flight, flight: flight)
+  end
+
+  test 'copies existing to new on different pilot_flight' do
+    copied = @existing.copy_to_pilot_flight(@pf)
+    refute_equal(@existing.id, copied.id)
+    assert_equal(@pf.id, copied.pilot_flight_id)
+    assert_equal(@existing.judge_id, copied.judge_id)
+    assert_equal(@existing.values, copied.values)
+  end
+
+  test 'does not create duplicate on pilot_flight' do
+    copied = @existing.copy_to_pilot_flight(@pf)
+    copied_too = @existing.copy_to_pilot_flight(@pf)
+    assert_equal(copied, copied_too)
+  end
+end

--- a/test/models/synthetic_category_test.rb
+++ b/test/models/synthetic_category_test.rb
@@ -13,4 +13,24 @@ class SyntheticCategoryTest < ActiveSupport::TestCase
     assert_equal(Array, synthetic_category.regular_category_flights.class)
     assert_equal(Array, synthetic_category.synthetic_category_flights.class)
   end
+
+  test 'creates synthetic category' do
+    cur_ct = Category.count
+    cat = synthetic_category.find_or_create
+    refute_nil(cat)
+    assert_equal(cur_ct + 1, Category.count)
+    assert_operator(0, '<', cat.id)
+    assert_equal(synthetic_category.synthetic_category_name, cat.category)
+    assert_equal(synthetic_category.synthetic_category_description, cat.name)
+    reg_cat = synthetic_category.regular_category
+    assert_equal(reg_cat.aircat, cat.aircat)
+    assert(cat.synthetic)
+    assert_equal(Category.pluck(:sequence).max, cat.sequence)
+  end
+
+  test 'finds existing synthetic category' do
+    cat = synthetic_category.find_or_create
+    cat_too = synthetic_category.find_or_create
+    assert_equal(cat, cat_too)
+  end
 end

--- a/test/models/synthetic_category_test.rb
+++ b/test/models/synthetic_category_test.rb
@@ -1,0 +1,16 @@
+require "test_helper"
+
+class SyntheticCategoryTest < ActiveSupport::TestCase
+  def synthetic_category
+    @synthetic_category ||= build :synthetic_category
+  end
+
+  def test_valid
+    assert synthetic_category.valid?
+  end
+
+  def test_serialized
+    assert_equal(Array, synthetic_category.regular_category_flights.class)
+    assert_equal(Array, synthetic_category.synthetic_category_flights.class)
+  end
+end

--- a/test/services/category_synthesis_service_test.rb
+++ b/test/services/category_synthesis_service_test.rb
@@ -1,0 +1,45 @@
+require 'test_helper'
+
+class CategorySynthesisServiceTest < ActiveSupport::TestCase
+  setup do
+    @synthetic_cat = create(:synthetic_category)
+    pilots = create_list(:member, 6)
+    judges = create_list(:judge, 4)
+    flights = @synthetic_cat.synthetic_category_flights.collect do |name|
+      flight = create(:flight,
+        name: name,
+        contest_id: @synthetic_cat.contest_id,
+        category_id: @synthetic_cat.regular_category_id
+      )
+      pilots.each do |pilot|
+        pf = create(:pilot_flight, pilot: pilot, flight: flight)
+        judges.each do |judge|
+          create(:score, pilot_flight: pf, judge: judge)
+        end
+      end
+      flight
+    end
+    css = CategorySynthesisService.new(@synthetic_cat)
+    css.synthesize_category
+  end
+
+  test 'copies flights to synthetic category' do
+    cat = @synthetic_cat.find_or_create
+    flights = Flight.where(
+      contest: @synthetic_cat.contest,
+      category: cat
+    )
+    flight_names = flights.collect(&:name).sort
+    assert_equal(flight_names, @synthetic_cat.synthetic_category_flights.sort)
+  end
+
+  test 'removes non-regular category flights' do
+    cat = @synthetic_cat.regular_category
+    flights = Flight.where(
+      contest: @synthetic_cat.contest,
+      category: cat
+    )
+    flight_names = flights.collect(&:name).sort
+    assert_equal(flight_names, @synthetic_cat.regular_category_flights.sort)
+  end
+end


### PR DESCRIPTION
Closes #22 

This provides a data driven method to synthesize a category for a contest from another category of that contest, and groom both categories with data from selected flights. The category on which the synthesis is based is called the "regular" category. The other is called the "synthetic" category.

The synthesis occurs as a call to a new CategorySynthesisService as part of the ComputeFlightsJob background job run to compute results for the contest. Thus all of the result computation artifacts are properly computed and created for both the regular and synthetic categories.

The CategorySynthesisService creates the synthetic category if it does not exist, always with an aircat value the same as the regular category and marked as synthetic. It arranges flights for the synthetic category copied from the regular category. It then removes flights from the regular category that don't belong there, according to values in the `_flights` columns of the synthetic_categories table.

The category table has lousy column names:
 - first, it has a column also called "category". This is the name of the category, such as "advanced" or "unlimited"
- second, it has a "name" column. This is a description of the category that is used for display, such as "Advanced Power".