### PR TITLE
Add synthesized category by m2m relation of flights

### DIFF
--- a/app/controllers/further_controller.rb
+++ b/app/controllers/further_controller.rb
@@ -13,9 +13,11 @@ class FurtherController < ApplicationController
     judge_counts = JyResult.select('count(distinct(judge_id)) as count, year').group(:year)
     @cat_year_judge_count['any'] = judge_counts.group_by { |count| count.year }
 
-    pilot_counts = PilotFlight.joins(:flight => [:category, :contest]).select(
-      'count(distinct(`pilot_flights`.`pilot_id`)) as count, categories.id as category_id, 
-       year(`contests`.`start`) as year').group(:category_id, :year)
+    pilot_counts = PilotFlight.joins(:flight => [:categories, :contest]).select(
+      'count(distinct(`pilot_flights`.`pilot_id`)) as count,
+       categories.id as category_id,
+       year(`contests`.`start`) as year'
+    ).group(:category_id, :year)
     @cat_year_pilot_count = pilot_counts.group_by { |pf| pf.category_id }
     @cat_year_pilot_count.each do |key, apcr| 
       @cat_year_pilot_count[key] = apcr.group_by { |pcr| pcr.year }
@@ -37,7 +39,7 @@ class FurtherController < ApplicationController
       ).all.collect { |contest| contest.anum }
     @year = params[:year] || @years.first
     airplanes_with_cat = Airplane.joins([
-      {:pilot_flights => {:flight => [:category, :contest]}},
+      {:pilot_flights => {:flight => [:categories, :contest]}},
       :make_model
       ]).select(
         'count(pilot_flights.id) as flight_count',

--- a/app/controllers/scores_controller.rb
+++ b/app/controllers/scores_controller.rb
@@ -1,13 +1,11 @@
 class ScoresController < ApplicationController
-
   # GET pilot/:pilot_id/scores/:contest_id
   def show
     @contest = Contest.find(params[:id])
     @pilot = Member.find(params[:pilot_id])
-    @pilot_flights = PilotFlight.joins(:flight => :categories).where(
+    @pilot_flights = PilotFlight.includes(:flight => :categories).where(
        {:pilot_flights => {pilot_id: @pilot},
         :flights => {contest_id: @contest}}
       ).order("categories.sequence, flights.sequence")
   end
-
 end

--- a/app/controllers/scores_controller.rb
+++ b/app/controllers/scores_controller.rb
@@ -4,7 +4,7 @@ class ScoresController < ApplicationController
   def show
     @contest = Contest.find(params[:id])
     @pilot = Member.find(params[:pilot_id])
-    @pilot_flights = PilotFlight.joins(:flight => :category).where(
+    @pilot_flights = PilotFlight.joins(:flight => :categories).where(
        {:pilot_flights => {pilot_id: @pilot},
         :flights => {contest_id: @contest}}
       ).order("categories.sequence, flights.sequence")

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -1,5 +1,5 @@
 class Category < ApplicationRecord
-  has_many :flights
+  has_and_belongs_to_many :flights
   has_many :region_pilots
   has_many :results
   has_many :jc_results, :dependent => :destroy

--- a/app/models/contest/show_results.rb
+++ b/app/models/contest/show_results.rb
@@ -54,21 +54,21 @@ module Contest::ShowResults
   def category_results
     categories = []
     if !flights.empty?
-      cats = flights.collect { |f| f.category }
-      cats = cats.uniq.sort { |a,b| a.sequence <=> b.sequence }
+      cats = flights.collect { |f| f.categories }
+      cats = cats.flatten.uniq.sort { |a,b| a.sequence <=> b.sequence }
       cats.each do |cat|
         category_data = {}
         category_data[:cat] = cat
         category_data[:judge_results] = jc_results.where(
           category: cat).includes(:judge)
-        category_data[:flights] = flights.where(
-          category: cat).all.sort { |a,b| a.sequence <=> b.sequence }
+        category_data[:flights] = cat.flights.where(
+          contest: self).all.sort { |a,b| a.sequence <=> b.sequence }
         category_data[:chiefs] = flights_chiefs(category_data[:flights])
         category_data[:pilot_results] = []
         pcrs = pc_results.where(category:cat).includes(:pilot).order(:category_rank)
         if !pcrs.empty?
           pf_results = PfResult.joins({:pilot_flight => :flight}).where(
-             {:flights => {contest_id: id, category_id: cat}})
+             {:flights => { id: flights.collect(&:id) }})
           pfr_by_flight = pf_results.all.group_by do |pf|
             pf.flight
           end

--- a/app/models/flight.rb
+++ b/app/models/flight.rb
@@ -1,6 +1,6 @@
 class Flight < ApplicationRecord
   belongs_to :contest
-  belongs_to :category
+  has_and_belongs_to_many :categories
   belongs_to :chief,
     :foreign_key => "chief_id", :class_name => 'Member', optional: true
   belongs_to :assist,

--- a/app/models/flight.rb
+++ b/app/models/flight.rb
@@ -15,11 +15,11 @@ class Flight < ApplicationRecord
   end
 
   def displayName
-    "#{displayCategory} #{name if category.category != 'four minute'}"
+    "#{displayCategory} #{name if categories.first.category != 'four minute'}"
   end
 
   def displayCategory
-    category.name
+    categories.collect(&:name).join(', ')
   end
 
   def display_chief

--- a/app/models/jc_result.rb
+++ b/app/models/jc_result.rb
@@ -15,7 +15,7 @@ class JcResult < ApplicationRecord
 
   def compute_category_totals
     zero_reset
-    flights = contest.flights.where(category: category)
+    flights = category.flights.where(contest: contest)
     flights.each do |flight|
       flight.jf_results.each do |jf_result|
         accumulate(jf_result) if jf_result.judge.judge == self.judge

--- a/app/models/pc_result.rb
+++ b/app/models/pc_result.rb
@@ -33,7 +33,7 @@ class PcResult < ApplicationRecord
   def compute_category_totals
     self.category_value = 0.0
     self.total_possible = 0
-    flights = contest.flights.where(category: category)
+    flights = category.flights.where(contest: contest)
     flights.each do |flight|
       pf_results = PfResult.joins(:pilot_flight).where(
         { pilot_flights: {pilot_id: pilot, flight_id: flight}})

--- a/app/models/pilot_flight.rb
+++ b/app/models/pilot_flight.rb
@@ -9,7 +9,7 @@ class PilotFlight < ApplicationRecord
   has_many :pf_results, :dependent => :destroy
   has_many :pfj_results, :dependent => :destroy
   has_one :contest, :through => :flight
-  has_one :category, :through => :flight
+  has_many :categories, :through => :flight
 
   def to_s
     a = "Pilot_flight #{id} #{flight} for pilot #{pilot}"

--- a/app/models/synthetic_category.rb
+++ b/app/models/synthetic_category.rb
@@ -3,4 +3,20 @@ class SyntheticCategory < ApplicationRecord
   belongs_to :regular_category, class_name: 'Category'
   serialize :regular_category_flights
   serialize :synthetic_category_flights
+
+  def find_or_create
+    last_seq = Category.pluck(:sequence).max
+    begin
+      cat = Category.find_or_create_by(
+        category: self.synthetic_category_name,
+        aircat: regular_category.aircat,
+      ) do |c|
+        c.sequence = last_seq + 1
+        c.name = self.synthetic_category_description
+        c.synthetic = true
+      end
+    rescue ActiveRecord::RecordNotUnique
+      retry
+    end
+  end
 end

--- a/app/models/synthetic_category.rb
+++ b/app/models/synthetic_category.rb
@@ -5,7 +5,7 @@ class SyntheticCategory < ApplicationRecord
   serialize :synthetic_category_flights
 
   def find_or_create
-    last_seq = Category.pluck(:sequence).max
+    last_seq = Category.maximum(:sequence)
     begin
       cat = Category.find_or_create_by(
         category: regular_category.category,

--- a/app/models/synthetic_category.rb
+++ b/app/models/synthetic_category.rb
@@ -8,11 +8,11 @@ class SyntheticCategory < ApplicationRecord
     last_seq = Category.pluck(:sequence).max
     begin
       cat = Category.find_or_create_by(
-        category: self.synthetic_category_name,
+        category: regular_category.category,
         aircat: regular_category.aircat,
+        name: self.synthetic_category_description
       ) do |c|
         c.sequence = last_seq + 1
-        c.name = self.synthetic_category_description
         c.synthetic = true
       end
     rescue ActiveRecord::RecordNotUnique

--- a/app/models/synthetic_category.rb
+++ b/app/models/synthetic_category.rb
@@ -1,0 +1,6 @@
+class SyntheticCategory < ApplicationRecord
+  belongs_to :contest
+  belongs_to :regular_category, class_name: 'Category'
+  serialize :regular_category_flights
+  serialize :synthetic_category_flights
+end

--- a/app/services/acro/contest_reader.rb
+++ b/app/services/acro/contest_reader.rb
@@ -92,14 +92,14 @@ def create_or_replace_pilot_flight(pilot_flight_data)
   if (category && name && aircat)
     cat = Category.find_for_cat_aircat(category, aircat)
     logger.info "Category is #{cat.inspect}"
-    Flight.where(
-      :contest_id => @contest_record, 
-      :name => name, 
-      :category_id => cat.id).destroy_all
+    cat.flights.where(
+      :contest_id => @contest_record,
+      :name => name
+    ).destroy_all
     flight = @contest_record.flights.build(
      :name => name,
-     :category_id => cat.id,
      :sequence => 0)
+    flight.categories << cat
     flight.save!
     @flights[pilot_flight_data.flightID] = flight
   else

--- a/app/services/category_rollups.rb
+++ b/app/services/category_rollups.rb
@@ -6,7 +6,7 @@ class CategoryRollups
 
   # return flights for this category of this contest
   def flights
-    @contest.flights.where(:category => @category)
+    @category.flights.where(contest: @contest)
   end
 
   # compute pilot results for this category of this contest

--- a/app/services/category_synthesis_service.rb
+++ b/app/services/category_synthesis_service.rb
@@ -1,0 +1,25 @@
+class CategorySynthesisService
+  def initialize(synthetic_category)
+    @sc = synthetic_category
+  end
+
+  def synthesize_category
+    reg_cat = @sc.regular_category
+    syn_cat = @sc.find_or_create
+    reg_flights = Flight.where(contest: @sc.contest, category: reg_cat)
+    @sc.synthetic_category_flights.each do |name|
+      reg_flight = Flight.find_by(
+        contest: @sc.contest, category: reg_cat, name: name
+      )
+      reg_flight.extend(FlightM::CopyToCategory)
+      reg_flight.copy_to_category(syn_cat)
+    end
+    non_reg_names =
+      @sc.synthetic_category_flights - @sc.regular_category_flights
+    Flight.where(
+      contest: @sc.contest, category: reg_cat, name: non_reg_names
+    ).each do |flight|
+      flight.destroy!
+    end
+  end
+end

--- a/app/services/category_synthesis_service.rb
+++ b/app/services/category_synthesis_service.rb
@@ -4,6 +4,9 @@ class CategorySynthesisService
     reg_cat = sc.regular_category
     syn_cat = sc.find_or_create
     reg_flights = reg_cat.flights.where(contest: sc.contest)
+    reg_flights.each do |flight|
+      flight.categories.delete(syn_cat)
+    end
     sc.synthetic_category_flights.each do |name|
       reg_flight = reg_flights.find_by(name: name)
       reg_flight.categories << syn_cat if reg_flight

--- a/app/services/category_synthesis_service.rb
+++ b/app/services/category_synthesis_service.rb
@@ -1,25 +1,28 @@
 class CategorySynthesisService
-  def initialize(synthetic_category)
-    @sc = synthetic_category
-  end
-
-  def synthesize_category
-    reg_cat = @sc.regular_category
-    syn_cat = @sc.find_or_create
-    reg_flights = Flight.where(contest: @sc.contest, category: reg_cat)
-    @sc.synthetic_category_flights.each do |name|
+  def self.synthesize_category(synthetic_category)
+    sc = synthetic_category # shorthand
+    reg_cat = sc.regular_category
+    syn_cat = sc.find_or_create
+    reg_flights = Flight.where(contest: sc.contest, category: reg_cat)
+    sc.synthetic_category_flights.each do |name|
       reg_flight = Flight.find_by(
-        contest: @sc.contest, category: reg_cat, name: name
+        contest: sc.contest, category: reg_cat, name: name
       )
       reg_flight.extend(FlightM::CopyToCategory)
       reg_flight.copy_to_category(syn_cat)
     end
     non_reg_names =
-      @sc.synthetic_category_flights - @sc.regular_category_flights
+      sc.synthetic_category_flights - sc.regular_category_flights
     Flight.where(
-      contest: @sc.contest, category: reg_cat, name: non_reg_names
+      contest: sc.contest, category: reg_cat, name: non_reg_names
     ).each do |flight|
       flight.destroy!
+    end
+  end
+
+  def self.synthesize_categories(contest)
+    SyntheticCategory.where(contest: contest).each do |sc|
+      self.synthesize_category(sc)
     end
   end
 end

--- a/app/services/contest_computer.rb
+++ b/app/services/contest_computer.rb
@@ -50,8 +50,10 @@ class ContestComputer
 
   # ensure contest pilot rollup computations for this contest are complete
   def compute_contest_pilot_rollups
-    cats = @contest.flights.collect { |f| f.category }
-    cats = cats.uniq
+    cats = @contest.flights.collect do |f|
+      f.categories
+    end
+    cats = cats.flatten.uniq
     cats.each do |cat|
       compute_category_rollups(cat)
     end
@@ -66,8 +68,8 @@ class ContestComputer
 
   # ensure contest judge rollup computations for this contest are complete
   def compute_contest_judge_rollups
-    cats = @contest.flights.collect { |f| f.category }
-    cats = cats.uniq
+    cats = @contest.flights.collect { |f| f.categories }
+    cats = cats.flatten.uniq
     cats.each do |cat|
       roller = CategoryRollups.new(@contest, cat)
       roller.compute_judge_category_results

--- a/app/services/contest_computer.rb
+++ b/app/services/contest_computer.rb
@@ -50,9 +50,7 @@ class ContestComputer
 
   # ensure contest pilot rollup computations for this contest are complete
   def compute_contest_pilot_rollups
-    cats = @contest.flights.collect do |f|
-      f.categories
-    end
+    cats = @contest.flights.collect { |f| f.categories }
     cats = cats.flatten.uniq
     cats.each do |cat|
       compute_category_rollups(cat)

--- a/app/services/iac/find_stars.rb
+++ b/app/services/iac/find_stars.rb
@@ -53,7 +53,7 @@ def process_for_stars
   end
   Category.all.each do |cat|
     catch (:category) do
-      catFlights = contest.flights.where({ :category_id => cat.id })
+      catFlights = cat.flights.where(contest: contest)
       ctFMin = (cat.category =~ /primary|sportsman/i) ? 1 : 2
       if (ctFMin <= catFlights.length) then
         flight = catFlights.first

--- a/app/services/iac/hors_concours_participants.rb
+++ b/app/services/iac/hors_concours_participants.rb
@@ -10,9 +10,7 @@ module IAC
 
     def mark_solo_participants_as_hc
       flights = @contest.flights
-      categories = flights.collect do |f|
-        f.categories.all
-      end
+      categories = flights.collect { |f| f.categories }
       categories = categories.flatten.uniq
       flights_by_cat = {}
       flights.each do |f|

--- a/app/services/jasper/jasper_to_db.rb
+++ b/app/services/jasper/jasper_to_db.rb
@@ -119,14 +119,18 @@ module Jasper
     def flight_for(d_contest, dCategory, jasper, jCat, jFlt)
       chief = chief_for(jasper, jCat, jFlt)
       assist = chief_assist_for(jasper, jCat, jFlt)
-      category_id = dCategory.id
-      d_contest.flights.where(category_id: category_id, sequence: jFlt).first ||
-        d_contest.flights.create!(
-          :category_id => category_id,
+      dFlight = dCategory.flights.find_by(contest: d_contest, sequence: jFlt)
+      unless dFlight
+        dFlight = d_contest.flights.build(
           :name => jasper.flight_name(jFlt),
           :sequence => jFlt,
           :chief_id => chief.id,
-          :assist_id => assist.id)
+          :assist_id => assist.id
+        )
+        dFlight.categories << dCategory
+        dFlight.save!
+      end
+      dFlight
     end
 
     def member_for(iac_id, given_name, family_name)

--- a/app/services/jobs/compute_flights_job.rb
+++ b/app/services/jobs/compute_flights_job.rb
@@ -8,6 +8,7 @@ class ComputeFlightsJob < Struct.new(:contest)
   def perform
     @contest = contest
     say "Computing flights for #{@contest.year_name}"
+    CategorySynthesisService.synthesize_categories(@contest)
     computer = ContestComputer.new(@contest)
     computer.compute_flights
   end

--- a/app/services/manny/manny_to_db.rb
+++ b/app/services/manny/manny_to_db.rb
@@ -151,7 +151,7 @@ def process_flight(mContest, mCat, mFlight, seq)
     dFlight = Flight.new(:name => mFlight.name, :sequence => seq)
     dFlight.chief = @parts[mFlight.chief] if mFlight.chief
     dFlight.contest = @dContest
-    dFlight.category = dCategory
+    dFlight.categories << dCategory
     dFlight.save!
     process_flight_judges(dFlight, mFlight)
     process_flight_scores(dFlight, mContest, mCat, mFlight)

--- a/app/views/flights/show.json.jbuilder
+++ b/app/views/flights/show.json.jbuilder
@@ -4,8 +4,9 @@ json.flight do
     json.partial! 'contest', contest: @flight.contest
     json.url contest_url(@flight.contest, :format => :json)
   end
-  json.category do
-    json.partial! 'categories/category', category: @flight.category
+  json.categories do
+    json.array! @flight.categories,
+      partial: 'categories/category', as: :category
   end
   json.pilot_results do
     json.partial! 'pilot_flights', collection: @flight.pilot_flights, :as => :pf

--- a/app/views/pilot_flights/_flight.json.jbuilder
+++ b/app/views/pilot_flights/_flight.json.jbuilder
@@ -1,3 +1,6 @@
 json.(flight, :id, :name)
 json.url flight_url(flight, :format => :json)
-json.category flight.category.name
+json.categories do
+  json.array! flight.categories,
+    partial: 'categories/category', as: :category
+end

--- a/db/migrate/20190919151543_create_synthetic_categories.rb
+++ b/db/migrate/20190919151543_create_synthetic_categories.rb
@@ -1,0 +1,16 @@
+class CreateSyntheticCategories < ActiveRecord::Migration[5.1]
+  def change
+    create_table :synthetic_categories, id: :integer do |t|
+      t.references :contest, type: :integer, foreign_key: true
+      t.references :regular_category, type: :integer
+      t.text :regular_category_flights
+      t.string :synthetic_category_name
+      t.string :synthetic_category_description
+      t.text :synthetic_category_flights
+
+      t.foreign_key(:categories, column: :regular_category_id,
+        on_delete: :cascade, on_update: :cascade)
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20190921120240_add_synthetic_flag_to_category.rb
+++ b/db/migrate/20190921120240_add_synthetic_flag_to_category.rb
@@ -1,0 +1,5 @@
+class AddSyntheticFlagToCategory < ActiveRecord::Migration[5.1]
+  def change
+    add_column :categories, :synthetic, :boolean, null: false, default: false
+  end
+end

--- a/db/migrate/20190923131409_add_multiple_categories_for_flights.rb
+++ b/db/migrate/20190923131409_add_multiple_categories_for_flights.rb
@@ -1,0 +1,8 @@
+class AddMultipleCategoriesForFlights < ActiveRecord::Migration[5.1]
+  def change
+    create_table :flight_categories, id: false do |t|
+      t.references :flight, type: :integer, null: false, foreign_key: true
+      t.references :category, type: :integer, null: false, foreign_key: true
+    end
+  end
+end

--- a/db/migrate/20190923131409_add_multiple_categories_for_flights.rb
+++ b/db/migrate/20190923131409_add_multiple_categories_for_flights.rb
@@ -1,6 +1,6 @@
 class AddMultipleCategoriesForFlights < ActiveRecord::Migration[5.1]
   def change
-    create_table :flight_categories, id: false do |t|
+    create_table :categories_flights, id: false do |t|
       t.references :flight, type: :integer, null: false, foreign_key: true
       t.references :category, type: :integer, null: false, foreign_key: true
     end

--- a/db/migrate/20190923140444_populate_flight_categories.rb
+++ b/db/migrate/20190923140444_populate_flight_categories.rb
@@ -1,0 +1,10 @@
+class PopulateFlightCategories < ActiveRecord::Migration[5.1]
+  def up
+    query = <<~SQL
+      INSERT INTO flight_categories (flight_id, category_id)
+        SELECT id, category_id
+        FROM flights
+    SQL
+    exec_query query
+  end
+end

--- a/db/migrate/20190923140444_populate_flight_categories.rb
+++ b/db/migrate/20190923140444_populate_flight_categories.rb
@@ -1,7 +1,7 @@
 class PopulateFlightCategories < ActiveRecord::Migration[5.1]
   def up
     query = <<~SQL
-      INSERT INTO flight_categories (flight_id, category_id)
+      INSERT INTO categories_flights (flight_id, category_id)
         SELECT id, category_id
         FROM flights
     SQL

--- a/db/migrate/20190923145028_rename_flights_category_id_column.rb
+++ b/db/migrate/20190923145028_rename_flights_category_id_column.rb
@@ -1,0 +1,5 @@
+class RenameFlightsCategoryIdColumn < ActiveRecord::Migration[5.1]
+  def change
+    rename_column(:flights, :category_id, :obsolete_category_reference)
+  end
+end

--- a/db/migrate/20190923230605_index_categories_flights.rb
+++ b/db/migrate/20190923230605_index_categories_flights.rb
@@ -1,0 +1,5 @@
+class IndexCategoriesFlights < ActiveRecord::Migration[5.1]
+  def change
+    add_index(:categories_flights, [:category_id, :flight_id], unique: true)
+  end
+end

--- a/db/migrate/20190923231126_index_category_name.rb
+++ b/db/migrate/20190923231126_index_category_name.rb
@@ -1,0 +1,5 @@
+class IndexCategoryName < ActiveRecord::Migration[5.1]
+  def change
+    add_index :categories, [:category, :aircat, :name], unique: true
+  end
+end

--- a/db/migrate/20190923232802_remove_synthetic_category_name.rb
+++ b/db/migrate/20190923232802_remove_synthetic_category_name.rb
@@ -1,0 +1,5 @@
+class RemoveSyntheticCategoryName < ActiveRecord::Migration[5.1]
+  def change
+    remove_column :synthetic_categories, :synthetic_category_name, :string
+  end
+end

--- a/db/migrate/20190924134741_lengthen_contest_category_name.rb
+++ b/db/migrate/20190924134741_lengthen_contest_category_name.rb
@@ -1,0 +1,12 @@
+class LengthenContestCategoryName < ActiveRecord::Migration[5.1]
+  def up
+    change_column :categories, :name, :string, limit: 48, null: false
+    change_column :synthetic_categories, :synthetic_category_description,
+      :string, limit: 48, null: false
+  end
+  def down
+    change_column :categories, :name, :string, limit: 32, null: false
+    change_column :synthetic_categories, :synthetic_category_description,
+      :string, null: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,9 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190905130441) do
+ActiveRecord::Schema.define(version: 20190919151543) do
 
-  create_table "airplanes", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci" do |t|
+  create_table "airplanes", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci" do |t|
     t.string "reg"
     t.datetime "created_at"
     t.datetime "updated_at"
@@ -20,7 +20,7 @@ ActiveRecord::Schema.define(version: 20190905130441) do
     t.index ["id"], name: "index_airplanes_on_id"
   end
 
-  create_table "categories", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci" do |t|
+  create_table "categories", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci" do |t|
     t.integer "sequence", null: false
     t.string "category", limit: 16, null: false
     t.string "aircat", limit: 1, null: false
@@ -30,7 +30,7 @@ ActiveRecord::Schema.define(version: 20190905130441) do
     t.index ["id"], name: "index_categories_on_id"
   end
 
-  create_table "contests", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci" do |t|
+  create_table "contests", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci" do |t|
     t.string "name", limit: 48
     t.string "city", limit: 24
     t.string "state", limit: 2
@@ -43,7 +43,7 @@ ActiveRecord::Schema.define(version: 20190905130441) do
     t.index ["id"], name: "index_contests_on_id"
   end
 
-  create_table "data_posts", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci" do |t|
+  create_table "data_posts", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci" do |t|
     t.integer "contest_id"
     t.boolean "is_integrated", default: false
     t.boolean "has_error", default: false
@@ -55,7 +55,7 @@ ActiveRecord::Schema.define(version: 20190905130441) do
     t.index ["id"], name: "index_data_posts_on_id"
   end
 
-  create_table "delayed_jobs", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci" do |t|
+  create_table "delayed_jobs", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci" do |t|
     t.integer "priority", default: 0
     t.integer "attempts", default: 0
     t.text "handler", limit: 16777215
@@ -70,7 +70,7 @@ ActiveRecord::Schema.define(version: 20190905130441) do
     t.index ["priority", "run_at"], name: "delayed_jobs_priority"
   end
 
-  create_table "failures", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci" do |t|
+  create_table "failures", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci" do |t|
     t.string "step", limit: 16
     t.integer "contest_id"
     t.integer "manny_id"
@@ -84,7 +84,7 @@ ActiveRecord::Schema.define(version: 20190905130441) do
     t.index ["manny_id"], name: "index_failures_on_manny_id"
   end
 
-  create_table "flights", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci" do |t|
+  create_table "flights", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci" do |t|
     t.integer "contest_id", null: false
     t.string "name", limit: 16, null: false
     t.integer "sequence", null: false
@@ -100,7 +100,7 @@ ActiveRecord::Schema.define(version: 20190905130441) do
     t.index ["id"], name: "index_flights_on_id"
   end
 
-  create_table "jc_results", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci" do |t|
+  create_table "jc_results", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci" do |t|
     t.integer "judge_id", null: false
     t.integer "pilot_count"
     t.decimal "sigma_ri_delta", precision: 11, scale: 5
@@ -127,7 +127,7 @@ ActiveRecord::Schema.define(version: 20190905130441) do
     t.index ["judge_id"], name: "index_jc_results_on_judge_id"
   end
 
-  create_table "jf_results", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci" do |t|
+  create_table "jf_results", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci" do |t|
     t.integer "judge_id"
     t.integer "pilot_count"
     t.decimal "sigma_ri_delta", precision: 10, scale: 5
@@ -152,7 +152,7 @@ ActiveRecord::Schema.define(version: 20190905130441) do
     t.index ["judge_id"], name: "index_jf_results_on_judge_id"
   end
 
-  create_table "judges", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci" do |t|
+  create_table "judges", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci" do |t|
     t.integer "judge_id"
     t.integer "assist_id"
     t.datetime "created_at"
@@ -162,7 +162,7 @@ ActiveRecord::Schema.define(version: 20190905130441) do
     t.index ["judge_id"], name: "index_judges_on_judge_id"
   end
 
-  create_table "jy_results", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci" do |t|
+  create_table "jy_results", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci" do |t|
     t.integer "judge_id"
     t.integer "category_id"
     t.integer "year"
@@ -188,7 +188,7 @@ ActiveRecord::Schema.define(version: 20190905130441) do
     t.index ["judge_id"], name: "index_jy_results_on_judge_id"
   end
 
-  create_table "make_models", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci" do |t|
+  create_table "make_models", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci" do |t|
     t.string "make", limit: 80
     t.string "model", limit: 80
     t.integer "empty_weight_lbs", limit: 2
@@ -203,7 +203,7 @@ ActiveRecord::Schema.define(version: 20190905130441) do
     t.index ["model"], name: "index_make_models_on_model"
   end
 
-  create_table "manny_synches", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci" do |t|
+  create_table "manny_synches", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci" do |t|
     t.integer "contest_id"
     t.integer "manny_number"
     t.datetime "synch_date"
@@ -212,7 +212,7 @@ ActiveRecord::Schema.define(version: 20190905130441) do
     t.index ["contest_id"], name: "index_manny_synches_on_contest_id"
   end
 
-  create_table "members", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci" do |t|
+  create_table "members", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci" do |t|
     t.integer "iac_id"
     t.string "given_name", limit: 40
     t.string "family_name", limit: 40
@@ -222,7 +222,7 @@ ActiveRecord::Schema.define(version: 20190905130441) do
     t.index ["id"], name: "index_members_on_id"
   end
 
-  create_table "pc_results", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci" do |t|
+  create_table "pc_results", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci" do |t|
     t.integer "pilot_id", null: false
     t.decimal "category_value", precision: 8, scale: 2
     t.integer "category_rank"
@@ -240,7 +240,7 @@ ActiveRecord::Schema.define(version: 20190905130441) do
     t.index ["pilot_id"], name: "index_pc_results_on_pilot_id"
   end
 
-  create_table "pf_results", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci" do |t|
+  create_table "pf_results", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci" do |t|
     t.integer "pilot_flight_id", null: false
     t.decimal "flight_value", precision: 7, scale: 2
     t.decimal "adj_flight_value", precision: 7, scale: 2
@@ -256,7 +256,7 @@ ActiveRecord::Schema.define(version: 20190905130441) do
     t.index ["pilot_flight_id"], name: "index_pf_results_on_pilot_flight_id"
   end
 
-  create_table "pfj_results", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci" do |t|
+  create_table "pfj_results", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci" do |t|
     t.integer "pilot_flight_id", null: false
     t.integer "judge_id", null: false
     t.string "computed_values"
@@ -273,7 +273,7 @@ ActiveRecord::Schema.define(version: 20190905130441) do
     t.index ["pilot_flight_id"], name: "index_pfj_results_on_pilot_flight_id"
   end
 
-  create_table "pilot_flights", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci" do |t|
+  create_table "pilot_flights", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci" do |t|
     t.integer "pilot_id"
     t.integer "flight_id"
     t.integer "sequence_id"
@@ -290,7 +290,7 @@ ActiveRecord::Schema.define(version: 20190905130441) do
     t.index ["sequence_id"], name: "index_pilot_flights_on_sequence_id"
   end
 
-  create_table "region_contests", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci" do |t|
+  create_table "region_contests", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci" do |t|
     t.integer "pc_result_id"
     t.integer "regional_pilot_id"
     t.datetime "created_at"
@@ -300,7 +300,7 @@ ActiveRecord::Schema.define(version: 20190905130441) do
     t.index ["regional_pilot_id"], name: "index_region_contests_on_regional_pilot_id"
   end
 
-  create_table "regional_pilots", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci" do |t|
+  create_table "regional_pilots", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci" do |t|
     t.integer "pilot_id"
     t.string "region", limit: 16, null: false
     t.integer "year"
@@ -315,7 +315,7 @@ ActiveRecord::Schema.define(version: 20190905130441) do
     t.index ["pilot_id"], name: "index_regional_pilots_on_pilot_id"
   end
 
-  create_table "result_accums", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci" do |t|
+  create_table "result_accums", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci" do |t|
     t.integer "result_id"
     t.integer "pc_result_id"
     t.datetime "created_at", null: false
@@ -325,7 +325,7 @@ ActiveRecord::Schema.define(version: 20190905130441) do
     t.index ["result_id"], name: "index_result_accums_on_result_id"
   end
 
-  create_table "result_members", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci" do |t|
+  create_table "result_members", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci" do |t|
     t.integer "member_id"
     t.integer "result_id"
     t.datetime "created_at", null: false
@@ -335,7 +335,7 @@ ActiveRecord::Schema.define(version: 20190905130441) do
     t.index ["result_id"], name: "index_result_members_on_result_id"
   end
 
-  create_table "results", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci" do |t|
+  create_table "results", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci" do |t|
     t.string "type"
     t.integer "year"
     t.integer "category_id"
@@ -353,7 +353,7 @@ ActiveRecord::Schema.define(version: 20190905130441) do
     t.index ["pilot_id"], name: "index_results_on_pilot_id"
   end
 
-  create_table "scores", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci" do |t|
+  create_table "scores", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci" do |t|
     t.integer "pilot_flight_id"
     t.integer "judge_id"
     t.string "values"
@@ -364,7 +364,7 @@ ActiveRecord::Schema.define(version: 20190905130441) do
     t.index ["pilot_flight_id"], name: "index_scores_on_pilot_flight_id"
   end
 
-  create_table "sequences", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci" do |t|
+  create_table "sequences", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci" do |t|
     t.integer "figure_count"
     t.integer "total_k"
     t.integer "mod_3_total"
@@ -375,11 +375,19 @@ ActiveRecord::Schema.define(version: 20190905130441) do
     t.index ["id"], name: "index_sequences_on_id"
   end
 
-  create_table "writers", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
-    t.string "name"
+  create_table "synthetic_categories", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci" do |t|
+    t.integer "contest_id"
+    t.integer "regular_category_id"
+    t.text "regular_category_flights"
+    t.string "synthetic_category_name"
+    t.string "synthetic_category_description"
+    t.text "synthetic_category_flights"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["id"], name: "index_writers_on_id"
+    t.index ["contest_id"], name: "index_synthetic_categories_on_contest_id"
+    t.index ["regular_category_id"], name: "index_synthetic_categories_on_regular_category_id"
   end
 
+  add_foreign_key "synthetic_categories", "categories", column: "regular_category_id", on_update: :cascade, on_delete: :cascade
+  add_foreign_key "synthetic_categories", "contests"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190923232802) do
+ActiveRecord::Schema.define(version: 20190924134741) do
 
   create_table "airplanes", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci" do |t|
     t.string "reg"
@@ -24,7 +24,7 @@ ActiveRecord::Schema.define(version: 20190923232802) do
     t.integer "sequence", null: false
     t.string "category", limit: 16, null: false
     t.string "aircat", limit: 1, null: false
-    t.string "name", limit: 32, null: false
+    t.string "name", limit: 48, null: false
     t.datetime "created_at"
     t.datetime "updated_at"
     t.boolean "synthetic", default: false, null: false
@@ -389,7 +389,7 @@ ActiveRecord::Schema.define(version: 20190923232802) do
     t.integer "contest_id"
     t.integer "regular_category_id"
     t.text "regular_category_flights"
-    t.string "synthetic_category_description"
+    t.string "synthetic_category_description", limit: 48, null: false
     t.text "synthetic_category_flights"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190919151543) do
+ActiveRecord::Schema.define(version: 20190921120240) do
 
   create_table "airplanes", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci" do |t|
     t.string "reg"
@@ -27,6 +27,7 @@ ActiveRecord::Schema.define(version: 20190919151543) do
     t.string "name", limit: 32, null: false
     t.datetime "created_at"
     t.datetime "updated_at"
+    t.boolean "synthetic", default: false, null: false
     t.index ["id"], name: "index_categories_on_id"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190923140444) do
+ActiveRecord::Schema.define(version: 20190923145028) do
 
   create_table "airplanes", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci" do |t|
     t.string "reg"
@@ -100,12 +100,12 @@ ActiveRecord::Schema.define(version: 20190923140444) do
     t.integer "assist_id"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.integer "category_id"
+    t.integer "obsolete_category_reference"
     t.index ["assist_id"], name: "index_flights_on_assist_id"
-    t.index ["category_id"], name: "index_flights_on_category_id"
     t.index ["chief_id"], name: "index_flights_on_chief_id"
     t.index ["contest_id"], name: "index_flights_on_contest_id"
     t.index ["id"], name: "index_flights_on_id"
+    t.index ["obsolete_category_reference"], name: "index_flights_on_obsolete_category_reference"
   end
 
   create_table "jc_results", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci" do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190923145028) do
+ActiveRecord::Schema.define(version: 20190923230605) do
 
   create_table "airplanes", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci" do |t|
     t.string "reg"
@@ -34,6 +34,7 @@ ActiveRecord::Schema.define(version: 20190923145028) do
   create_table "categories_flights", id: false, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci" do |t|
     t.integer "flight_id", null: false
     t.integer "category_id", null: false
+    t.index ["category_id", "flight_id"], name: "index_categories_flights_on_category_id_and_flight_id", unique: true
     t.index ["category_id"], name: "index_categories_flights_on_category_id"
     t.index ["flight_id"], name: "index_categories_flights_on_flight_id"
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190923231126) do
+ActiveRecord::Schema.define(version: 20190923232802) do
 
   create_table "airplanes", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci" do |t|
     t.string "reg"
@@ -389,7 +389,6 @@ ActiveRecord::Schema.define(version: 20190923231126) do
     t.integer "contest_id"
     t.integer "regular_category_id"
     t.text "regular_category_flights"
-    t.string "synthetic_category_name"
     t.string "synthetic_category_description"
     t.text "synthetic_category_flights"
     t.datetime "created_at", null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190923131409) do
+ActiveRecord::Schema.define(version: 20190923140444) do
 
   create_table "airplanes", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci" do |t|
     t.string "reg"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190921120240) do
+ActiveRecord::Schema.define(version: 20190923131409) do
 
   create_table "airplanes", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci" do |t|
     t.string "reg"
@@ -83,6 +83,13 @@ ActiveRecord::Schema.define(version: 20190921120240) do
     t.index ["data_post_id"], name: "index_failures_on_data_post_id"
     t.index ["id"], name: "index_failures_on_id"
     t.index ["manny_id"], name: "index_failures_on_manny_id"
+  end
+
+  create_table "flight_categories", id: false, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci" do |t|
+    t.integer "flight_id", null: false
+    t.integer "category_id", null: false
+    t.index ["category_id"], name: "index_flight_categories_on_category_id"
+    t.index ["flight_id"], name: "index_flight_categories_on_flight_id"
   end
 
   create_table "flights", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci" do |t|
@@ -389,6 +396,8 @@ ActiveRecord::Schema.define(version: 20190921120240) do
     t.index ["regular_category_id"], name: "index_synthetic_categories_on_regular_category_id"
   end
 
+  add_foreign_key "flight_categories", "categories"
+  add_foreign_key "flight_categories", "flights"
   add_foreign_key "synthetic_categories", "categories", column: "regular_category_id", on_update: :cascade, on_delete: :cascade
   add_foreign_key "synthetic_categories", "contests"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190923230605) do
+ActiveRecord::Schema.define(version: 20190923231126) do
 
   create_table "airplanes", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci" do |t|
     t.string "reg"
@@ -28,6 +28,7 @@ ActiveRecord::Schema.define(version: 20190923230605) do
     t.datetime "created_at"
     t.datetime "updated_at"
     t.boolean "synthetic", default: false, null: false
+    t.index ["category", "aircat", "name"], name: "index_categories_on_category_and_aircat_and_name", unique: true
     t.index ["id"], name: "index_categories_on_id"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -31,6 +31,13 @@ ActiveRecord::Schema.define(version: 20190923145028) do
     t.index ["id"], name: "index_categories_on_id"
   end
 
+  create_table "categories_flights", id: false, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci" do |t|
+    t.integer "flight_id", null: false
+    t.integer "category_id", null: false
+    t.index ["category_id"], name: "index_categories_flights_on_category_id"
+    t.index ["flight_id"], name: "index_categories_flights_on_flight_id"
+  end
+
   create_table "contests", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci" do |t|
     t.string "name", limit: 48
     t.string "city", limit: 24
@@ -83,13 +90,6 @@ ActiveRecord::Schema.define(version: 20190923145028) do
     t.index ["data_post_id"], name: "index_failures_on_data_post_id"
     t.index ["id"], name: "index_failures_on_id"
     t.index ["manny_id"], name: "index_failures_on_manny_id"
-  end
-
-  create_table "flight_categories", id: false, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci" do |t|
-    t.integer "flight_id", null: false
-    t.integer "category_id", null: false
-    t.index ["category_id"], name: "index_flight_categories_on_category_id"
-    t.index ["flight_id"], name: "index_flight_categories_on_flight_id"
   end
 
   create_table "flights", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci" do |t|
@@ -396,8 +396,8 @@ ActiveRecord::Schema.define(version: 20190923145028) do
     t.index ["regular_category_id"], name: "index_synthetic_categories_on_regular_category_id"
   end
 
-  add_foreign_key "flight_categories", "categories"
-  add_foreign_key "flight_categories", "flights"
+  add_foreign_key "categories_flights", "categories"
+  add_foreign_key "categories_flights", "flights"
   add_foreign_key "synthetic_categories", "categories", column: "regular_category_id", on_update: :cascade, on_delete: :cascade
   add_foreign_key "synthetic_categories", "contests"
 end

--- a/spec/acro/contest_reader_spec.rb
+++ b/spec/acro/contest_reader_spec.rb
@@ -80,7 +80,9 @@ module ACRO
       fla = ct.flights
       expect(fla.size).to eq(1)
       fl = fla.first
-      cat = fl.category
+      cats = fl.categories
+      expect(cats.count).to eq(1)
+      cat = cats.first
       expect(cat.category).to eq('advanced')
       expect(cat.aircat).to eq('P')
       expect(fl.name).to eq('Free')

--- a/spec/controllers/flights_controller_spec.rb
+++ b/spec/controllers/flights_controller_spec.rb
@@ -29,7 +29,7 @@ describe FlightsController, :type => :controller do
     d_fl = data['flight']
     d_cat = d_fl['category']
     expect(d_cat).to_not be nil
-    cat = @flight.category
+    cat = @flight.category.first
     expect(d_cat['sequence']).to eq cat.sequence
     expect(d_cat['aircat']).to eq cat.aircat
     expect(d_cat['name']).to eq cat.name

--- a/spec/controllers/flights_controller_spec.rb
+++ b/spec/controllers/flights_controller_spec.rb
@@ -27,13 +27,16 @@ describe FlightsController, :type => :controller do
     get :show, params: { id: @flight.id }, :format => :json
     data = JSON.parse(response.body)
     d_fl = data['flight']
-    d_cat = d_fl['category']
-    expect(d_cat).to_not be nil
-    cat = @flight.category.first
-    expect(d_cat['sequence']).to eq cat.sequence
-    expect(d_cat['aircat']).to eq cat.aircat
-    expect(d_cat['name']).to eq cat.name
-    expect(d_cat['level']).to eq cat.category
+    d_cats = d_fl['categories']
+    expect(d_cats).to_not be nil
+    expect(d_cats.length).to eq @flight.categories.count
+    d_cats.each do |d_cat|
+      cat = @flight.categories.find_by(sequence: d_cat['sequence'])
+      expect(cat).to_not be nil
+      expect(d_cat['aircat']).to eq cat.aircat
+      expect(d_cat['name']).to eq cat.name
+      expect(d_cat['level']).to eq cat.category
+    end
   end
   it 'includes pilot flights' do
     get :show, params: { id: @flight.id }, :format => :json

--- a/spec/controllers/judges_controller_spec.rb
+++ b/spec/controllers/judges_controller_spec.rb
@@ -19,13 +19,17 @@ describe JudgesController, :type => :controller do
     unl_cat = Category.where(category: 'Unlimited', aircat: 'P').first
     spn_cat = Category.where(category: 'Sportsman', aircat: 'P').first
     imd_cat = Category.where(category: 'Intermediate', aircat: 'P').first
-    c1fa = create :flight, category: adv_cat,
+    c1fa = create :flight,
+      category: adv_cat.category, aircat: adv_cat.aircat,
       chief: cj, assist: cja
-    c1fs = create :flight, category: spn_cat, contest: c1fa.contest, 
+    c1fs = create :flight, contest: c1fa.contest,
+      category: spn_cat.category, aircat: spn_cat.aircat,
       chief: cj, assist: cja
-    c2fa = create :flight, category: adv_cat,
+    c2fa = create :flight,
+      category: adv_cat.category, aircat: adv_cat.aircat,
       chief: cj, assist: cja
-    c2fs = create :flight, category: spn_cat, contest: c2fa.contest,
+    c2fs = create :flight, contest: c2fa.contest,
+      category: spn_cat.category, aircat: spn_cat.aircat,
       chief: cj, assist: nil
     [c1fa, c1fs, c2fa, c2fs].each do |flt|
       pf = create :pilot_flight, flight: flt

--- a/spec/controllers/pilot_flights_controller_spec.rb
+++ b/spec/controllers/pilot_flights_controller_spec.rb
@@ -49,7 +49,9 @@ describe PilotFlightsController, :type => :controller do
     expect(d_f['url']).to eq flight_url(flight, :format => :json)
     expect(d_f['id']).to eq flight.id
     expect(d_f['name']).to eq flight.name
-    expect(d_f['category']).to eq flight.category.name
+    d_cats = d_f['categories']
+    expect(d_cats).to_not be nil
+    expect(d_cats.length).to eq flight.categories.count
   end
   it 'responds with judge flight grades for pilot' do
     get :show, params: { id: @pilot_flight.id }, :format => :json

--- a/spec/factories/model.rb
+++ b/spec/factories/model.rb
@@ -106,6 +106,7 @@ FactoryBot.define do
       category { 'intermediate' }
       aircat { 'P' }
       seq { (Category.pluck(:sequence).max || 0) + 1 }
+      name { nil }
     end
     initialize_with do
       factory_cat = Category.where(
@@ -114,7 +115,7 @@ FactoryBot.define do
       unless factory_cat
         factory_cat = Category.create(
           category: category, aircat: aircat, sequence: seq,
-          name: Faker::Book.unique.title
+          name: (name || Faker::Book.unique.title)
         )
       end
       factory_cat

--- a/spec/factories/model.rb
+++ b/spec/factories/model.rb
@@ -107,22 +107,32 @@ FactoryBot.define do
       aircat { 'P' }
     end
     initialize_with do
-      factory_cat = Category.where(:category => category, :aircat => aircat).first
+      factory_cat = Category.where(
+        :category => category, :aircat => aircat
+      ).order(:sequence).first
       unless factory_cat
         sequence = Category.select('MAX sequence').first.sequence + 1
-        factory_cat = Category.create(:category => cat, :aircat => aircat, :sequence => sequence)
+        factory_cat = Category.create(
+          :category => cat, :aircat => aircat, :sequence => sequence)
       end
       factory_cat
     end
   end
 ### Flight
   factory :flight do
+    transient do 
+      category { 'intermediate' }
+      aircat { 'P' }
+    end
     association :contest
-    association :category
     association :chief, :factory => :member
     association :assist, :factory => :member
     name { 'Known' }
     sequence(:sequence)
+    after(:create) do |flight, ev|
+      cat = create(:category, category: ev.category, aircat: ev.aircat)
+      flight.categories << cat
+    end
   end
   factory :nationals_imdt_known, :class => Flight do
     association :contest, :factory => :nationals

--- a/spec/factories/model.rb
+++ b/spec/factories/model.rb
@@ -138,18 +138,16 @@ FactoryBot.define do
       end
       flight.categories << cat
     end
-  end
-  factory :nationals_imdt_known, :class => Flight do
-    association :contest, :factory => :nationals
-    association :category
-    name { 'Known' }
-    sequence(:sequence) { |n| n }
-  end
-  factory :nationals_imdt_free, :class => Flight do |r|
-    r.association :contest, :factory => :nationals
-    r.association :category
-    r.name { 'Free' }
-    r.sequence(:sequence) { |n| n }
+    factory :nationals_imdt_known do
+      association :contest, :factory => :nationals
+      name { 'Known' }
+      sequence(:sequence) { |n| n }
+    end
+    factory :nationals_imdt_free, :class => Flight do |r|
+      r.association :contest, :factory => :nationals
+      r.name { 'Free' }
+      r.sequence(:sequence) { |n| n }
+    end
   end
 ### Sequence
   factory :sequence, class: Sequence do

--- a/spec/factories/model.rb
+++ b/spec/factories/model.rb
@@ -105,15 +105,15 @@ FactoryBot.define do
     transient do 
       category { 'intermediate' }
       aircat { 'P' }
+      seq { (Category.pluck(:sequence).max || 0) + 1 }
     end
     initialize_with do
       factory_cat = Category.where(
         :category => category, :aircat => aircat
       ).order(:sequence).first
       unless factory_cat
-        sequence = Category.pluck(:sequence).max + 1
         factory_cat = Category.create(
-          category: category, aircat: aircat, sequence: sequence,
+          category: category, aircat: aircat, sequence: seq,
           name: aircat.capitalize)
       end
       factory_cat

--- a/spec/factories/model.rb
+++ b/spec/factories/model.rb
@@ -114,7 +114,8 @@ FactoryBot.define do
       unless factory_cat
         factory_cat = Category.create(
           category: category, aircat: aircat, sequence: seq,
-          name: aircat.capitalize)
+          name: Faker::Book.unique.title
+        )
       end
       factory_cat
     end

--- a/spec/factories/model.rb
+++ b/spec/factories/model.rb
@@ -103,7 +103,7 @@ FactoryBot.define do
 ### Category
   factory :category do
     transient do 
-      category { 'Intermediate' }
+      category { 'intermediate' }
       aircat { 'P' }
     end
     initialize_with do
@@ -111,9 +111,10 @@ FactoryBot.define do
         :category => category, :aircat => aircat
       ).order(:sequence).first
       unless factory_cat
-        sequence = Category.select('MAX sequence').first.sequence + 1
+        sequence = Category.pluck(:sequence).max + 1
         factory_cat = Category.create(
-          :category => cat, :aircat => aircat, :sequence => sequence)
+          category: category, aircat: aircat, sequence: sequence,
+          name: aircat.capitalize)
       end
       factory_cat
     end

--- a/spec/factories/model.rb
+++ b/spec/factories/model.rb
@@ -123,6 +123,7 @@ FactoryBot.define do
     transient do 
       category { 'intermediate' }
       aircat { 'P' }
+      category_id { nil }
     end
     association :contest
     association :chief, :factory => :member
@@ -130,7 +131,11 @@ FactoryBot.define do
     name { 'Known' }
     sequence(:sequence)
     after(:create) do |flight, ev|
-      cat = create(:category, category: ev.category, aircat: ev.aircat)
+      if (ev.category_id)
+        cat = Category.find(ev.category_id)
+      else
+        cat = create(:category, category: ev.category, aircat: ev.aircat)
+      end
       flight.categories << cat
     end
   end

--- a/spec/factories/synthetic_categories.rb
+++ b/spec/factories/synthetic_categories.rb
@@ -1,0 +1,24 @@
+FactoryBot.define do
+  factory :synthetic_category do
+    transient do
+      regular_category_name { 'Advanced' }
+      regular_category_aircat { 'P' }
+      flight_names { ['Known', 'Free', 'Unknown I'] }
+      extra_flight_names { ['Unknown II'] }
+    end
+    initialize_with do
+      contest = create(:contest)
+      regular_category = create(:category,
+        category: regular_category_name, aircat: regular_category_aircat)
+      syncat = SyntheticCategory.new(contest: contest,
+        regular_category: regular_category)
+      syncat.regular_category_flights = flight_names
+      syncat.synthetic_category_name =
+        [regular_category_name, 'team'].join(' ')
+      syncat.synthetic_category_description =
+        [regular_category_name, 'team'].join(' ').camelcase
+      syncat.synthetic_category_flights = flight_names + extra_flight_names
+      syncat
+    end
+  end
+end

--- a/spec/factories/synthetic_categories.rb
+++ b/spec/factories/synthetic_categories.rb
@@ -13,8 +13,6 @@ FactoryBot.define do
       syncat = SyntheticCategory.new(contest: contest,
         regular_category: regular_category)
       syncat.regular_category_flights = flight_names
-      syncat.synthetic_category_name =
-        [regular_category_name, 'team'].join(' ')
       syncat.synthetic_category_description =
         [regular_category_name, 'team'].join(' ').camelcase
       syncat.synthetic_category_flights = flight_names + extra_flight_names

--- a/spec/features/contests/show_contest_spec.rb
+++ b/spec/features/contests/show_contest_spec.rb
@@ -1,10 +1,10 @@
 describe 'show contest' do
   def build_contest_category_flights(contest, category, chief)
-    first = create(:flight, contest: contest, category: category,
+    first = create(:flight, contest: contest, category_id: category.id,
       chief: chief)
-    second = create(:flight, contest: contest, category: category,
+    second = create(:flight, contest: contest, category_id: category.id,
       chief: chief, name: 'Free')
-    third = create(:flight, contest: contest, category: category,
+    third = create(:flight, contest: contest, category_id: category.id,
       chief: chief, name: 'Unknown')
     pfs = create_list(:pilot_flight, 7, flight: first)
     [second, third].each do |flight|
@@ -41,7 +41,8 @@ describe 'show contest' do
       fspn.chief = cj2
       fspn.save!
       visit contest_path(@contest)
-      spnh = find(:xpath, "//div[@id='content']/h3[text()='#{fspn.category.name}']")
+      fspn_cat = fspn.categories.first
+      spnh = find(:xpath, "//div[@id='content']/h3[text()='#{fspn_cat.name}']")
       ptbl = spnh.first(:xpath, "following-sibling::table[@class='pilot_results']")
       expect(ptbl).to_not be nil
       pfcj = ptbl.first(:xpath, "following-sibling::p[@class='category-chief']")

--- a/spec/iac/sa_computer_spec.rb
+++ b/spec/iac/sa_computer_spec.rb
@@ -5,15 +5,15 @@ module IAC
         @category = Category.find_by_category_and_aircat('intermediate', 'P')
         @pilot_flight = create(:adams_known)
         judge_team = create(:judge_klein)
-        create(:adams_known_klein, 
+        create(:adams_known_klein,
           :pilot_flight => @pilot_flight,
           :judge => judge_team)
         @judge_jim = create(:judge_jim)
-        create(:adams_known_jim, 
+        create(:adams_known_jim,
           :pilot_flight => @pilot_flight,
           :judge => @judge_jim)
         judge_team = create(:judge_lynne)
-        create(:adams_known_lynne, 
+        create(:adams_known_lynne,
           :pilot_flight => @pilot_flight,
           :judge => judge_team)
         @sa_computer = SaComputer.new(@pilot_flight)

--- a/spec/manny/manny2db_spec.rb
+++ b/spec/manny/manny2db_spec.rb
@@ -29,8 +29,7 @@ module Manny
     end
     it 'captures a sportsman submitted free for a second flight' do
       category = Category.find_for_cat_aircat('Sportsman', 'P')
-      flight = @contest.flights.where( :name => 'Free', 
-        :category_id => category.id).first
+      flight = category.flights.find_by(contest: @contest, name: 'Free')
       expect(flight).not_to be nil
       pilot = Member.where(:family_name => 'Hartvigsen').first
       expect(pilot).not_to be nil
@@ -44,8 +43,7 @@ module Manny
     end
     it 'captures a sportsman submitted free for a third flight' do
       category = Category.find_for_cat_aircat('Sportsman', 'P')
-      flight = @contest.flights.where( :name => 'Unknown', 
-        :category_id => category.id).first
+      flight = category.flights.find_by(contest: @contest, name: 'Unknown')
       expect(flight).not_to be nil
       pilot = Member.where(:family_name => 'Hartvigsen').first
       expect(pilot).not_to be nil
@@ -59,8 +57,7 @@ module Manny
     end
     it 'captures the sportsman known for a second flight' do
       category = Category.find_for_cat_aircat('Sportsman', 'P')
-      flight = @contest.flights.where( :name => 'Unknown', 
-        :category_id => category.id).first
+      flight = category.flights.find_by(contest: @contest, name: 'Unknown')
       expect(flight).not_to be nil
       pilot = Member.where(:family_name => 'Cohen').first
       expect(pilot).not_to be nil
@@ -74,8 +71,7 @@ module Manny
     end
     it 'gets the intermediate unknown' do
       category = Category.find_for_cat_aircat('Intermediate', 'P')
-      flight = @contest.flights.where( :name => 'Unknown', 
-        :category_id => category.id).first
+      flight = category.flights.find_by(contest: @contest, name: 'Unknown')
       expect(flight).not_to be nil
       pilot = Member.where(:family_name => 'Wells').first
       expect(pilot).not_to be nil
@@ -89,8 +85,7 @@ module Manny
     end
     it 'captures scores' do
       category = Category.find_for_cat_aircat('Sportsman', 'P')
-      flight = @contest.flights.where( :name => 'Free', 
-        :category_id => category.id).first
+      flight = category.flights.find_by(contest: @contest, name: 'Free')
       expect(flight).not_to be nil
       pilot = Member.where(:family_name => 'Cohen').first # manny_id 6
       expect(pilot).not_to be nil
@@ -109,8 +104,7 @@ module Manny
     end
     it 'captures penalties' do
       category = Category.find_for_cat_aircat('Sportsman', 'P')
-      flight = @contest.flights.where( :name => 'Free', 
-        :category_id => category.id).first
+      flight = category.flights.find_by(contest: @contest, name: 'Free')
       expect(flight).not_to be nil
       pilot = Member.where(:family_name => 'Cohen').first # manny_id 6
       expect(pilot).not_to be nil

--- a/spec/models/jc_result_spec.rb
+++ b/spec/models/jc_result_spec.rb
@@ -6,7 +6,7 @@ module Model
         @category = Category.where(category: 'Unlimited', aircat: 'P').first
         @flight = create(:flight,
           :contest => @contest,
-          :category => @category)
+          :category_id => @category.id)
         @judge_team = create(:judge)
         @jc_result = create(:jc_result,
           :contest => @contest,

--- a/spec/models/jf_result_spec.rb
+++ b/spec/models/jf_result_spec.rb
@@ -2,7 +2,7 @@ describe JfResult, :type => :model do
   def reparse_contest(m2d, manny)
     @contest = m2d.process_contest(manny, true)
     @pri_cat = Category.find_by_category_and_aircat('primary', 'P')
-    @flight2 = @contest.flights.where(:category_id => @pri_cat.id, :name => 'Free').first
+    @flight2 = @pri_cat.flights.find_by(contest: @contest, :name => 'Free')
   end
   context 'computed contest' do
     before(:context) do
@@ -93,11 +93,11 @@ describe JfResult, :type => :model do
       j2db = Jasper::JasperToDB.new
       contest = j2db.process_contest(@jasper)
       pri_cat = Category.find_by_category_and_aircat('primary', 'P')
-      @pri_flight = contest.flights.where(:category_id => pri_cat.id, :name => 'Known').first
+      @pri_flight = pri_cat.flights.find_by(contest: contest, :name => 'Known')
       computer = FlightComputer.new(@pri_flight)
       computer.flight_results(false)
       spn_cat = Category.find_by_category_and_aircat('sportsman', 'P')
-      @spn_flight = contest.flights.where(:category_id => spn_cat.id, :name => 'Known').first
+      @spn_flight = spn_cat.flights.find_by(contest: contest, :name => 'Known')
       computer = FlightComputer.new(@spn_flight)
       computer.flight_results(false)
     end

--- a/spec/services/member_merge/recalc_spec.rb
+++ b/spec/services/member_merge/recalc_spec.rb
@@ -198,7 +198,7 @@ module MemberMerge
           t_cat = t_jc_result.category
           t_jy_result = create :jy_result, year: @t_contest.year,
             judge: @target_mr, category: t_cat
-          t_flight = create :flight, contest: @t_contest, category: t_cat
+          t_flight = create :flight, contest: @t_contest, category_id: t_cat.id
           t_pf = create :pilot_flight, flight: t_flight
           t_jp = create :judge, judge: @target_mr
           create :score, judge: t_jp, pilot_flight: t_pf
@@ -207,7 +207,7 @@ module MemberMerge
           r_cat = r_jc_result.category
           r_jy_result = create :jy_result, year: @r_contest.year,
             judge: @replace_mr, category: r_cat
-          r_flight = create :flight, contest: @r_contest, category: r_cat
+          r_flight = create :flight, contest: @r_contest, category_id: r_cat.id
           r_pf = create :pilot_flight, flight: r_flight
           r_jp = create :judge, judge: @replace_mr
           create :score, judge: r_jp, pilot_flight: r_pf

--- a/spec/services/member_merge/recalc_spec.rb
+++ b/spec/services/member_merge/recalc_spec.rb
@@ -253,14 +253,14 @@ module MemberMerge
           t_flight = create :flight, contest: @t_contest
           t_pf = create :pilot_flight, flight: t_flight, pilot: @target_mr
           create :score, pilot_flight: t_pf
-          t_cat = t_flight.category
+          t_cat = t_flight.categories.first
           create :pc_result, pilot: @target_mr, contest: @t_contest,
             category: t_cat
 
           r_flight = create :flight, contest: @r_contest
           r_pf = create :pilot_flight, flight: r_flight, pilot: @replace_mr
           create :score, pilot_flight: r_pf
-          r_cat = r_flight.category
+          r_cat = r_flight.categories.first
           create :pc_result, pilot: @replace_mr, contest: @r_contest,
             category: r_cat
 

--- a/spec/shared/computed_contest_context.rb
+++ b/spec/shared/computed_contest_context.rb
@@ -4,7 +4,8 @@ shared_context 'computed contest' do
     @contest = create :contest, year: @year
     @ctf = 3
     @category = Category.first
-    @flights = create_list :flight, @ctf, contest: @contest, category: @category
+    @flights = create_list :flight, @ctf, contest: @contest,
+      category: @category.category, aircat: @category.aircat
     @flight = @flights.first
     @pilots = create_list :member, 3
     @airplanes = create_list :airplane, 3

--- a/test/controllers/admin/make_model/preview_test.rb
+++ b/test/controllers/admin/make_model/preview_test.rb
@@ -3,6 +3,7 @@ require 'shared/make_models_data'
 
 class Admin::MakeModelPreviewTest < ActionDispatch::IntegrationTest
   include MakeModelsData
+  include MakeModelsHelper
 
   setup do
     @models = setup_make_models_with_airplanes
@@ -66,7 +67,7 @@ class Admin::MakeModelPreviewTest < ActionDispatch::IntegrationTest
       params: admin_make_models_select_params(@select_models)
     @select_models.each do |mm|
       assert_select('ul.make-model-airplanes-list li',
-          /#{mm.make}, #{mm.model}/) do
+          /#{make_model_description(mm).unicode_normalize}/) do
         mm.airplanes.each do |airplane|
           assert_select('ul li', /#{airplane.reg}/)
         end

--- a/test/controllers/admin/make_model/preview_test.rb
+++ b/test/controllers/admin/make_model/preview_test.rb
@@ -3,7 +3,6 @@ require 'shared/make_models_data'
 
 class Admin::MakeModelPreviewTest < ActionDispatch::IntegrationTest
   include MakeModelsData
-  include MakeModelsHelper
 
   setup do
     @models = setup_make_models_with_airplanes
@@ -66,8 +65,7 @@ class Admin::MakeModelPreviewTest < ActionDispatch::IntegrationTest
       headers: http_auth_login(:curator),
       params: admin_make_models_select_params(@select_models)
     @select_models.each do |mm|
-      assert_select('ul.make-model-airplanes-list li',
-          /#{make_model_description(mm).unicode_normalize}/) do
+      assert_select('ul.make-model-airplanes-list li') do
         mm.airplanes.each do |airplane|
           assert_select('ul li', /#{airplane.reg}/)
         end

--- a/test/controllers/contests_controller/show_test.rb
+++ b/test/controllers/contests_controller/show_test.rb
@@ -95,7 +95,7 @@ class ContestsController::ShowTest < ActionController::TestCase
     d_cr = d_crs.first
     d_jrs = d_cr['judge_results']
     assert(d_jrs)
-    assert_equal(3, d_jrs.count)
+    assert_equal(@judges.count, d_jrs.count)
     d_jr = d_jrs.first
     j_result = d_jr['result']
     assert(j_result)
@@ -113,7 +113,7 @@ class ContestsController::ShowTest < ActionController::TestCase
     d_cr = d_crs.first
     d_fdls = d_cr['flights']
     assert(d_fdls)
-    assert_equal(3, d_fdls.count)
+    assert_equal(@flights.count, d_fdls.count)
     d_f = d_fdls.first
     assert(d_f.has_key?('url'))
     assert_match(/^http/, d_f['url'])

--- a/test/controllers/contests_controller/show_test.rb
+++ b/test/controllers/contests_controller/show_test.rb
@@ -1,22 +1,11 @@
 require 'test_helper'
+require 'shared/basic_contest_data'
 
 class ContestsController::ShowTest < ActionController::TestCase
+  include BasicContestData
+
   setup do
-    @contest = create :contest
-    judge_pairs = create_list :judge, 3
-    @pilots = create_list :member, 3
-    @airplanes = create_list :airplane, 3
-    @flights = create_list :flight, 3, contest: @contest
-    @flights.each do |flight|
-      @pilots.each_with_index do |p, i|
-        pf = create :pilot_flight, flight: flight, pilot: p,
-          airplane: @airplanes[i]
-        judge_pairs.each do |j|
-          s = create :score, pilot_flight: pf, judge: j
-        end
-      end
-    end
-    @judges = judge_pairs.collect { |jp| jp.judge }
+    setup_basic_contest_data
     cc = ContestComputer.new(@contest)
     cc.compute_results
   end

--- a/test/controllers/contests_controller/show_test.rb
+++ b/test/controllers/contests_controller/show_test.rb
@@ -39,8 +39,8 @@ class ContestsController::ShowTest < ActionController::TestCase
   test 'contains categories flown' do
     get :show, params: { id: @contest.id }, :format => :json
     data = JSON.parse(response.body)
-    e_cats = @contest.flights.collect { |f| f.category }
-    e_cats = e_cats.uniq
+    e_cats = @contest.flights.collect { |f| f.categories }
+    e_cats = e_cats.flatten.uniq
     d_cats = data['category_results']
     assert_equal(e_cats.length, d_cats.length)
     e_cat_names = e_cats.collect { |c| c.name }

--- a/test/controllers/further_controller_test.rb
+++ b/test/controllers/further_controller_test.rb
@@ -8,7 +8,7 @@ class FurtherControllerTest < ActionDispatch::IntegrationTest
         create_list(:jy_result, 12 + Random.rand(12),
           year: year, category: category)
         contest = create(:contest, start: "#{year}-09-04")
-        flight = create(:flight, contest: contest, category: category)
+        flight = create(:flight, contest: contest, category_id: category.id)
         create_list(:pilot_flight, 12 + Random.rand(12), flight: flight)
       end
     end

--- a/test/controllers/scores_controller/show_test.rb
+++ b/test/controllers/scores_controller/show_test.rb
@@ -1,0 +1,28 @@
+require 'test_helper'
+require 'shared/basic_contest_data'
+
+class ScoresController::ShowTest < ActionController::TestCase
+  include BasicContestData
+
+  setup do
+    setup_basic_contest_data
+    cc = ContestComputer.new(@contest)
+    cc.compute_results
+  end
+
+  test 'shows contest flights with scores for one pilot' do
+    pilot = @pilots.first
+    get :show, params: { pilot_id: pilot.id, id: @contest.id }
+    assert_response :success
+  end
+
+  test 'contains all of the flights' do
+    pilot = @pilots.first
+    get :show, params: { pilot_id: pilot.id, id: @contest.id }
+    @flights.each do |flight|
+      assert_select(
+        "div.flightScores h3 a[href='#{flight_path(flight.id)}']")
+      assert_select('div.flightScores h3 a', flight.displayName)
+    end
+  end
+end

--- a/test/controllers/scores_controller/synthcat_test.rb
+++ b/test/controllers/scores_controller/synthcat_test.rb
@@ -9,10 +9,13 @@ class ScoresController::SynthcatTest < ActionController::TestCase
     cat = @flights.first.categories.first
     names = @flights.collect(&:name)
     synth_cat_name = "Synthetic Category for #{cat.category.capitalize}"
-    sc = SyntheticCategory.create(contest: @contest, regular_category: cat,
+    sc = SyntheticCategory.create(
+      contest: @contest, regular_category: cat,
       synthetic_category_description: synth_cat_name,
-      regular_category_flights: names, synthetic_category_flights:names)
+      regular_category_flights: names[0...-1],
+      synthetic_category_flights: names)
     CategorySynthesisService.synthesize_categories(@contest)
+    @flights.each(&:reload)
     cc = ContestComputer.new(@contest)
     cc.compute_results
   end
@@ -20,10 +23,9 @@ class ScoresController::SynthcatTest < ActionController::TestCase
   test 'contains the flights only once' do
     pilot = @pilots.first
     get :show, params: { pilot_id: pilot.id, id: @contest.id }
-    puts "BODY #{response.body}"
     @flights.each do |flight|
       assert_select(
-        "div.flightScores h3 a[href='#{flight_path(flight.id)}']")
+        "div.flightScores h3 a[href='#{flight_path(flight.id)}']", 1)
       assert_select('div.flightScores h3 a', flight.displayName)
     end
   end

--- a/test/controllers/scores_controller/synthcat_test.rb
+++ b/test/controllers/scores_controller/synthcat_test.rb
@@ -1,0 +1,30 @@
+require 'test_helper'
+require 'shared/basic_contest_data'
+
+class ScoresController::SynthcatTest < ActionController::TestCase
+  include BasicContestData
+
+  setup do
+    setup_basic_contest_data
+    cat = @flights.first.categories.first
+    names = @flights.collect(&:name)
+    synth_cat_name = "Synthetic Category for #{cat.category.capitalize}"
+    sc = SyntheticCategory.create(contest: @contest, regular_category: cat,
+      synthetic_category_description: synth_cat_name,
+      regular_category_flights: names, synthetic_category_flights:names)
+    CategorySynthesisService.synthesize_categories(@contest)
+    cc = ContestComputer.new(@contest)
+    cc.compute_results
+  end
+
+  test 'contains the flights only once' do
+    pilot = @pilots.first
+    get :show, params: { pilot_id: pilot.id, id: @contest.id }
+    puts "BODY #{response.body}"
+    @flights.each do |flight|
+      assert_select(
+        "div.flightScores h3 a[href='#{flight_path(flight.id)}']")
+      assert_select('div.flightScores h3 a', flight.displayName)
+    end
+  end
+end

--- a/test/models/contest/show_results_test.rb
+++ b/test/models/contest/show_results_test.rb
@@ -17,12 +17,13 @@ class Contest::ShowResultsTest < ActiveSupport::TestCase
   end
 
   test 'category results resilient to missing pilot_flight' do
-    flight = create(:flight, contest: @contest)
+    category = create(:category)
+    flight = create(:flight, category_id: category.id, contest: @contest)
     jf_result = create(:jf_result, flight: flight)
     pc_result = create(:pc_result,
       contest: @contest,
       pilot: create(:member),
-      category: flight.category
+      category: category
     )
     results = @contest.category_results
     cat_result = results.first

--- a/test/models/pc_result/computation_test.rb
+++ b/test/models/pc_result/computation_test.rb
@@ -10,7 +10,7 @@ class PcResult::ComputationTest < ActiveSupport::TestCase
     judge_lynne = create(:judge_lynne)
     known_flight = create(:nationals_imdt_known,
       :contest => @contest)
-    @imdt_cat = known_flight.category
+    @imdt_cat = known_flight.categories.first
     @adams_flight = create(:adams_known,
       :flight => known_flight, :pilot => @adams)
     create(:adams_known_klein, 
@@ -34,7 +34,7 @@ class PcResult::ComputationTest < ActiveSupport::TestCase
       :pilot_flight => denton_flight,
       :judge => judge_lynne)
     free_flight = create(:nationals_imdt_free,
-      :contest => @contest, :category => @imdt_cat)
+      :contest => @contest, :category_id => @imdt_cat.id)
     @adams_flight = create(:adams_free,
       :flight => free_flight, :pilot => @adams)
     create(:adams_free_klein, 

--- a/test/models/pc_result/pc_result_test.rb
+++ b/test/models/pc_result/pc_result_test.rb
@@ -2,10 +2,11 @@ require 'test_helper'
 
 class PcResult::PcResultTest < ActiveSupport::TestCase
   test 'finds cached data' do
-    pcr = create(:existing_pc_result)
+    category = create(:category)
+    pcr = create(:existing_pc_result, category: category)
     pc_result = PcResult.find_by(
       contest_id: pcr.contest_id,
-      category_id: pcr.category_id,
+      category_id: category.id,
       pilot_id: pcr.pilot_id
     )
     assert_equal(4992.14, pc_result.category_value)
@@ -14,7 +15,9 @@ class PcResult::PcResultTest < ActiveSupport::TestCase
 
   # This is really a test for FlightComputer
   test 'behaves on empty sequence' do
-    pf = create(:pilot_flight)
+    category = create(:category)
+    flight = create(:flight, category_id: category.id)
+    pf = create(:pilot_flight, flight: flight)
     create(:score,
       :pilot_flight => pf,
       :values => [60, 0, 0, 0, 0])
@@ -26,7 +29,7 @@ class PcResult::PcResultTest < ActiveSupport::TestCase
     computer.flight_results(false)
     pc_result = PcResult.find_by(
       contest_id: flight.contest_id,
-      category_id: flight.category_id,
+      category_id: category.id,
       pilot_id: pf.pilot_id
     )
     assert_nil(pc_result)

--- a/test/models/synthetic_category_test.rb
+++ b/test/models/synthetic_category_test.rb
@@ -15,14 +15,15 @@ class SyntheticCategoryTest < ActiveSupport::TestCase
   end
 
   test 'creates synthetic category' do
+    last_seq = Category.pluck(:sequence).max
     cur_ct = Category.count
     cat = synthetic_category.find_or_create
     refute_nil(cat)
     assert_equal(cur_ct + 1, Category.count)
-    assert_operator(0, '<', cat.id)
-    assert_equal(synthetic_category.synthetic_category_name, cat.category)
+    assert_equal(last_seq + 1, cat.sequence)
     assert_equal(synthetic_category.synthetic_category_description, cat.name)
     reg_cat = synthetic_category.regular_category
+    assert_equal(reg_cat.category, cat.category)
     assert_equal(reg_cat.aircat, cat.aircat)
     assert(cat.synthetic)
     assert_equal(Category.pluck(:sequence).max, cat.sequence)

--- a/test/models/synthetic_category_test.rb
+++ b/test/models/synthetic_category_test.rb
@@ -15,7 +15,7 @@ class SyntheticCategoryTest < ActiveSupport::TestCase
   end
 
   test 'creates synthetic category' do
-    last_seq = Category.pluck(:sequence).max
+    last_seq = Category.maximum(:sequence)
     cur_ct = Category.count
     cat = synthetic_category.find_or_create
     refute_nil(cat)

--- a/test/models/synthetic_category_test.rb
+++ b/test/models/synthetic_category_test.rb
@@ -13,4 +13,24 @@ class SyntheticCategoryTest < ActiveSupport::TestCase
     assert_equal(Array, synthetic_category.regular_category_flights.class)
     assert_equal(Array, synthetic_category.synthetic_category_flights.class)
   end
+
+  test 'creates synthetic category' do
+    cur_ct = Category.count
+    cat = synthetic_category.find_or_create
+    refute_nil(cat)
+    assert_equal(cur_ct + 1, Category.count)
+    assert_operator(0, '<', cat.id)
+    assert_equal(synthetic_category.synthetic_category_name, cat.category)
+    assert_equal(synthetic_category.synthetic_category_description, cat.name)
+    reg_cat = synthetic_category.regular_category
+    assert_equal(reg_cat.aircat, cat.aircat)
+    assert(cat.synthetic)
+    assert_equal(Category.pluck(:sequence).max, cat.sequence)
+  end
+
+  test 'finds existing synthetic category' do
+    cat = synthetic_category.find_or_create
+    cat_too = synthetic_category.find_or_create
+    assert_equal(cat, cat_too)
+  end
 end

--- a/test/models/synthetic_category_test.rb
+++ b/test/models/synthetic_category_test.rb
@@ -1,0 +1,16 @@
+require "test_helper"
+
+class SyntheticCategoryTest < ActiveSupport::TestCase
+  def synthetic_category
+    @synthetic_category ||= build :synthetic_category
+  end
+
+  def test_valid
+    assert synthetic_category.valid?
+  end
+
+  def test_serialized
+    assert_equal(Array, synthetic_category.regular_category_flights.class)
+    assert_equal(Array, synthetic_category.synthetic_category_flights.class)
+  end
+end

--- a/test/services/category_synthesis_service_test.rb
+++ b/test/services/category_synthesis_service_test.rb
@@ -28,7 +28,7 @@ class CategorySynthesisServiceTest < ActiveSupport::TestCase
   end
 
   def collect_flight_names(contest, cat)
-    flights = Flight.where(contest: contest, category: cat)
+    flights = cat.flights.where(contest: contest)
     flights.collect(&:name).sort
   end
 

--- a/test/services/category_synthesis_service_test.rb
+++ b/test/services/category_synthesis_service_test.rb
@@ -1,0 +1,45 @@
+require 'test_helper'
+
+class CategorySynthesisServiceTest < ActiveSupport::TestCase
+  setup do
+    @synthetic_cat = create(:synthetic_category)
+    pilots = create_list(:member, 6)
+    judges = create_list(:judge, 4)
+    flights = @synthetic_cat.synthetic_category_flights.collect do |name|
+      flight = create(:flight,
+        name: name,
+        contest_id: @synthetic_cat.contest_id,
+        category_id: @synthetic_cat.regular_category_id
+      )
+      pilots.each do |pilot|
+        pf = create(:pilot_flight, pilot: pilot, flight: flight)
+        judges.each do |judge|
+          create(:score, pilot_flight: pf, judge: judge)
+        end
+      end
+      flight
+    end
+    css = CategorySynthesisService.new(@synthetic_cat)
+    css.synthesize_category
+  end
+
+  test 'copies flights to synthetic category' do
+    cat = @synthetic_cat.find_or_create
+    flights = Flight.where(
+      contest: @synthetic_cat.contest,
+      category: cat
+    )
+    flight_names = flights.collect(&:name).sort
+    assert_equal(flight_names, @synthetic_cat.synthetic_category_flights.sort)
+  end
+
+  test 'removes non-regular category flights' do
+    cat = @synthetic_cat.regular_category
+    flights = Flight.where(
+      contest: @synthetic_cat.contest,
+      category: cat
+    )
+    flight_names = flights.collect(&:name).sort
+    assert_equal(flight_names, @synthetic_cat.regular_category_flights.sort)
+  end
+end

--- a/test/services/contest_computer/hors_concours_test.rb
+++ b/test/services/contest_computer/hors_concours_test.rb
@@ -13,7 +13,7 @@ class HorsConcoursTest < ActiveSupport::TestCase
   end
 
   def setup_flights(pilot, cat)
-    flights = create_list(:flight, 3, contest: @contest, category: cat)
+    flights = create_list(:flight, 3, contest: @contest, category_id: cat.id)
     flights.each do |flight|
       create(:pilot_flight, flight: flight, pilot: pilot)
       create_list(:pilot_flight, 3, flight: flight)
@@ -23,7 +23,7 @@ class HorsConcoursTest < ActiveSupport::TestCase
 
   def setup_4m_flight(pilot)
     four_cat = create(:category, category: 'four minute', aircat: 'F')
-    flight = create(:flight, contest: @contest, category: four_cat)
+    flight = create(:flight, contest: @contest, category_id: four_cat.id)
     create(:pilot_flight, flight: flight, pilot: pilot)
     create_list(:pilot_flight, 3, flight: flight)
     flight
@@ -46,13 +46,13 @@ class HorsConcoursTest < ActiveSupport::TestCase
   test 'identifies solo performance in category' do
     pilot = create :member
     spn_flights = create_list(:flight, 3,
-      contest: @contest, category: @spn_cat)
+      contest: @contest, category_id: @spn_cat.id)
     spn_flights.each do |flight|
       create(:pilot_flight, flight: flight, pilot: pilot)
     end
     @contest_computer.compute_results
 
-    flights = @contest.flights.where(category_id: @spn_cat.id)
+    flights = @spn_cat.flights.where(contest: @contest)
     assert_equal(3, flights.count)
     pfs = PilotFlight.where(flight_id: flights.collect(&:id))
     assert_equal(3, pfs.count)

--- a/test/services/iac/find_stars/find_stars_HZ_processed_test.rb
+++ b/test/services/iac/find_stars/find_stars_HZ_processed_test.rb
@@ -7,10 +7,10 @@ module IAC
       @ctst = create(:contest, name: 'Test Find Stars', start: '2019-03-27')
       @cat = create(:category, category: 'Sportsman', name: 'Sportsman Power')
       seq = create(:sequence, figure_count: 4, k_values: [20, 4, 15, 9])
-      flt = create(:flight, category: @cat, contest: @ctst)
+      flt = create(:flight, category_id: @cat.id, contest: @ctst)
       @pilot = create(:member)
       @pf = create(:pilot_flight, sequence: seq, flight: flt, pilot: @pilot)
-      flt2 = create(:flight, category: @cat, contest: @ctst, name: 'Free')
+      flt2 = create(:flight, category_id: @cat.id, contest: @ctst, name: 'Free')
       @pf2 = create(:pilot_flight, sequence: seq, flight: flt2, pilot: @pilot)
     end
 

--- a/test/services/iac/find_stars/find_stars_test.rb
+++ b/test/services/iac/find_stars/find_stars_test.rb
@@ -7,10 +7,10 @@ module IAC
       @ctst = create(:contest, name: 'Test Find Stars', start: '2018-03-27')
       @cat = create(:category, category: 'Sportsman', name: 'Sportsman Power')
       seq = create(:sequence, figure_count: 4, k_values: [20, 4, 15, 9])
-      flt = create(:flight, category: @cat, contest: @ctst)
+      flt = create(:flight, category_id: @cat.id, contest: @ctst)
       @pilot = create(:member)
       @pf = create(:pilot_flight, sequence: seq, flight: flt, pilot: @pilot)
-      flt2 = create(:flight, category: @cat, contest: @ctst, name: 'Free')
+      flt2 = create(:flight, category_id: @cat.id, contest: @ctst, name: 'Free')
       @pf2 = create(:pilot_flight, sequence: seq, flight: flt2, pilot: @pilot)
     end
 

--- a/test/services/iac/hors_concours/participants_test.rb
+++ b/test/services/iac/hors_concours/participants_test.rb
@@ -1,33 +1,13 @@
 require 'test_helper'
+require 'shared/hors_concours_data'
 
-module IAC
-  class HorsConcoursParticipantsTest < ActiveSupport::TestCase
-    def create_pilot_flights(flight, pilots)
-      sequence = create(:sequence)
-      pilots.collect do |pilot|
-        create(:pilot_flight, pilot: pilot, flight: flight, sequence: sequence)
-      end
-    end
+module IAC::HorsConcours
+  class ParticipantsTest < ActiveSupport::TestCase
+    include HorsConcoursData
 
     setup do
-      @lower_cat = Category.find_by(aircat: 'P', category: 'sportsman')
-      @higher_cat = Category.find_by(aircat: 'P', category: 'advanced')
-      @glider_cat = Category.find_by(aircat: 'G', category: 'sportsman')
-      @solo_cat = Category.find_by(aircat: 'P', category: 'unlimited')
-      @contest = create(:contest)
-      @pilots = create_list(:member, 7)
-
-      known_flight = create(:flight, contest: @contest, category: @higher_cat)
-      @known_flights = create_pilot_flights(known_flight, @pilots)
-
-      unknown_flight = create(:flight,
-        name: 'Unknown',
-        contest: @contest,
-        category: @higher_cat)
-      unknown_sequence = create(:sequence)
-      @unknown_flights = create_pilot_flights(unknown_flight, @pilots)
-
-      @hc = HorsConcoursParticipants.new(@contest)
+      setup_hors_concours_flights
+      @hc = IAC::HorsConcoursParticipants.new(@contest)
     end
 
     test 'does not mark non-solo, non-lower-category' do
@@ -40,7 +20,8 @@ module IAC
     end
 
     test 'marks solo participant pilot_flight' do
-      known_flight = create(:flight, contest: @contest, category: @solo_cat)
+      known_flight = create(:flight,
+        contest: @contest, category_id: @solo_cat.id)
       pf = create(:pilot_flight, flight: known_flight)
 
       @hc.mark_solo_participants_as_hc
@@ -51,7 +32,8 @@ module IAC
 
     test 'marks lower category participant pilot_flight' do
       pilot = @pilots.first
-      known_flight = create(:flight, contest: @contest, category: @lower_cat)
+      known_flight = create(:flight,
+        contest: @contest, category_id: @lower_cat.id)
       pf = create(:pilot_flight, pilot: pilot, flight: known_flight)
 
       @hc.mark_lower_category_participants_as_hc
@@ -62,7 +44,8 @@ module IAC
 
     test 'does not mark lower category pilot_flight in different class' do
       pilot = @pilots.first
-      known_flight = create(:flight, contest: @contest, category: @glider_cat)
+      known_flight = create(:flight,
+        contest: @contest, category_id: @glider_cat.id)
       pf = create(:pilot_flight, flight: known_flight)
 
       @hc.mark_lower_category_participants_as_hc
@@ -77,13 +60,15 @@ module IAC
       end
 
       pilot = @pilots.first
-      known_flight = create(:flight, contest: @contest, category: @lower_cat)
+      known_flight = create(:flight,
+        contest: @contest, category_id: @lower_cat.id)
       create_list(:pilot_flight, 3, flight: known_flight)
       pf = create(:pilot_flight, pilot: pilot, flight: known_flight)
       lc_result = create(:pc_result,
         pilot: pilot, contest: @contest, category: @lower_cat)
 
-      known_flight = create(:flight, contest: @contest, category: @solo_cat)
+      known_flight = create(:flight,
+        contest: @contest, category_id: @solo_cat.id)
       pf = create(:pilot_flight, flight: known_flight)
       sc_result = create(:pc_result,
         pilot: pf.pilot, contest: @contest, category: @solo_cat)

--- a/test/services/iac/hors_concours/synthetic_category_test.rb
+++ b/test/services/iac/hors_concours/synthetic_category_test.rb
@@ -8,12 +8,14 @@ module IAC::HorsConcours
     setup do
       setup_hors_concours_flights
       last_seq = Category.pluck(:sequence).max
-      synth_cat = Category.create(category: 'advanced', aircat: 'P',
-        name: 'Advanced Team', sequence: last_seq + 1, synthetic: true)
+      synth_cat = create(:category, category: 'advanced', aircat: 'P',
+        name: 'Advanced Team', seq: last_seq + 1, synthetic: true)
       @unknown_flights.each do |pf|
         flight = pf.flight
-        flight.categories << synth_cat
-        flight.save!
+        unless flight.categories.exists?(synth_cat.id)
+          flight.categories << synth_cat
+          flight.save!
+        end
       end
       @hc = IAC::HorsConcoursParticipants.new(@contest)
     end

--- a/test/services/iac/hors_concours/synthetic_category_test.rb
+++ b/test/services/iac/hors_concours/synthetic_category_test.rb
@@ -1,0 +1,29 @@
+require 'test_helper'
+require 'shared/hors_concours_data'
+
+module IAC::HorsConcours
+  class SyntheticCategoryTest < ActiveSupport::TestCase
+    include HorsConcoursData
+
+    setup do
+      setup_hors_concours_flights
+      last_seq = Category.pluck(:sequence).max
+      synth_cat = Category.create(category: 'advanced', aircat: 'P',
+        name: 'Advanced Team', sequence: last_seq + 1, synthetic: true)
+      @unknown_flights.each do |pf|
+        flight = pf.flight
+        flight.categories << synth_cat
+        flight.save!
+      end
+      @hc = IAC::HorsConcoursParticipants.new(@contest)
+    end
+
+    test 'does not treat synthetic as higher category' do
+      @hc.mark_lower_category_participants_as_hc
+      @unknown_flights.each do |flight|
+        refute(flight.reload.hors_concours?)
+        assert_equal(0, flight.hors_concours)
+      end
+    end
+  end
+end

--- a/test/services/jasper/empty_test.rb
+++ b/test/services/jasper/empty_test.rb
@@ -15,21 +15,21 @@ module Jasper
     test 'skips empty four minute program' do
       cat = Category.find_by(category: 'Four Minute')
       refute_nil(cat)
-      flights = @contest.flights.where(category: cat)
+      flights = cat.flights.where(contest: @contest)
       assert_equal(0, flights.count)
     end
 
     test 'skips empty unlimited power program' do
       cat = Category.find_by(category: 'Unlimited', aircat: 'P')
       refute_nil(cat)
-      flights = @contest.flights.where(category: cat)
+      flights = cat.flights.where(contest: @contest)
       assert_equal(0, flights.count)
     end
 
     test 'skips flight with pilots but no scores' do
       cat = Category.find_by(category: 'Advanced', aircat: 'P')
       refute_nil(cat)
-      flights = @contest.flights.where(category: cat)
+      flights = cat.flights.where(contest: @contest)
       assert_equal(2, flights.count)
     end
   end

--- a/test/services/jasper/jasper_to_db_test.rb
+++ b/test/services/jasper/jasper_to_db_test.rb
@@ -27,7 +27,7 @@ module Jasper
 
     test 'captures flights' do
       cat = Category.find_for_cat_aircat('Unlimited', 'P')
-      flights = @contest.flights.where(:category_id => cat.id, :name => 'Unknown')
+      flights = cat.flights.where(contest: @contest, :name => 'Unknown')
       assert_equal(1, flights.count)
       assert_equal(2383, flights.first.chief.iac_id)
       assert_equal(18515, flights.first.assist.iac_id)
@@ -55,7 +55,7 @@ module Jasper
 
     test 'captures pilot flights' do
       cat = Category.find_for_cat_aircat('Intermediate', 'P')
-      flight = @contest.flights.where(:category_id => cat.id, :name => 'Unknown').first
+      flight = cat.flights.find_by(contest: @contest, :name => 'Unknown')
       pilot = Member.find_by_iac_id(10467)
       pilot_flight = PilotFlight.find_by_flight_id_and_pilot_id(flight.id, pilot.id)
       refute_nil(pilot_flight)
@@ -64,7 +64,7 @@ module Jasper
 
     test 'captures airplanes' do
       cat = Category.find_for_cat_aircat('Sportsman', 'P')
-      flight = @contest.flights.where( :name => 'Known', :category_id => cat.id).first
+      flight = cat.flights.find_by(contest: @contest, :name => 'Known')
       refute_nil(flight)
       pilot = Member.where(:family_name => 'Ernewein').first
       refute_nil(pilot)
@@ -79,7 +79,7 @@ module Jasper
 
     test 'filters pilot chapter number' do
       cat = Category.find_for_cat_aircat('Sportsman', 'P')
-      flight = @contest.flights.where(category_id: cat.id, name: 'Known').first
+      flight = cat.flights.find_by(contest: @contest, :name => 'Known')
       pilot = Member.find_by_iac_id(12058)
       pilot_flight = PilotFlight.find_by_flight_id_and_pilot_id(flight.id, pilot.id)
       assert_equal('3/52', pilot_flight.chapter)

--- a/test/services/jasper/member_record_test.rb
+++ b/test/services/jasper/member_record_test.rb
@@ -33,7 +33,8 @@ module Jasper
       assert_equal(1, patch_pilots.count)
       patch_flights = PilotFlight.where(pilot_id: patch_pilots.first.id)
       patch_flights.each do |pf|
-        if pf.category.category == 'unlimited'
+        cats = pf.categories.collect(&:category)
+        if cats.include?('unlimited')
           assert(pf.hors_concours?)
         end
       end

--- a/test/services/jasper/scores_test.rb
+++ b/test/services/jasper/scores_test.rb
@@ -13,7 +13,7 @@ module Jasper
 
     test 'captures scores' do
       cat = Category.find_for_cat_aircat('Sportsman', 'P')
-      flight = @contest.flights.where( :name => 'Free', :category_id => cat.id).first
+      flight = cat.flights.find_by(name: 'Free', contest: @contest)
       refute_nil(flight)
       pilot = Member.where(:family_name => 'Ernewein').first
       refute_nil(pilot)
@@ -32,7 +32,7 @@ module Jasper
 
     test 'captures four minute free scores' do
       cat = Category.find_for_cat_aircat('Four Minute', 'F')
-      flight = @contest.flights.where(category_id: cat.id).first
+      flight = cat.flights.find_by(contest: @contest)
       refute_nil(flight)
       pilot = Member.where(iac_id: 13721).first
       refute_nil(pilot)

--- a/test/services/jasper/sequences_test.rb
+++ b/test/services/jasper/sequences_test.rb
@@ -13,7 +13,7 @@ module Jasper
 
     test 'captures known sequences' do
       cat = Category.find_for_cat_aircat('Sportsman', 'P')
-      flight = @contest.flights.where(name: 'Known', category_id: cat.id).first
+      flight = cat.flights.find_by(name: 'Known', contest: @contest)
       refute_nil(flight)
       pilot = Member.where(:family_name => 'Ernewein').first
       refute_nil(pilot)
@@ -28,7 +28,7 @@ module Jasper
 
     test 'captures free sequences' do
       cat = Category.find_for_cat_aircat('Sportsman', 'P')
-      flight = @contest.flights.where(name: 'Free', category_id: cat.id).first
+      flight = cat.flights.find_by(name: 'Free', contest: @contest)
       refute_nil(flight)
       pilot = Member.where(:family_name => 'Wieckowski').first
       refute_nil(pilot)
@@ -43,8 +43,7 @@ module Jasper
 
     test 'captures sportsman second free sequences' do
       cat = Category.find_for_cat_aircat('Sportsman', 'P')
-      flight = @contest.flights.where(
-        name: 'Unknown', category_id: cat.id).first
+      flight = cat.flights.find_by(name: 'Unknown', contest: @contest)
       refute_nil(flight)
       pilot = Member.where(:family_name => 'Wieckowski').first
       refute_nil(pilot)
@@ -59,8 +58,7 @@ module Jasper
 
     test 'captures unknown sequences' do
       cat = Category.find_for_cat_aircat('Unlimited', 'P')
-      flight = @contest.flights.where(
-        name: 'Unknown', category_id: cat.id).first
+      flight = cat.flights.find_by(name: 'Unknown', contest: @contest)
       refute_nil(flight)
       pilot = Member.where(:iac_id => '13721').first
       refute_nil(pilot)
@@ -76,8 +74,7 @@ module Jasper
 
     test 'captures second unknown sequences' do
       cat = Category.find_for_cat_aircat('Intermediate', 'P')
-      flight = @contest.flights.where(
-        name: 'Unknown II', category_id: cat.id).first
+      flight = cat.flights.find_by(name: 'Unknown II', contest: @contest)
       refute_nil(flight)
       pilot = Member.where(:iac_id => '10467').first
       refute_nil(pilot)
@@ -93,7 +90,7 @@ module Jasper
 
     test 'captures four minute free sequences' do
       cat = Category.find_for_cat_aircat('Four Minute', 'F')
-      flight = @contest.flights.where(category_id: cat.id).first
+      flight = cat.flights.find_by(contest: @contest)
       refute_nil(flight)
       pilot = Member.where(iac_id: 13721).first
       refute_nil(pilot)

--- a/test/services/jasper/unknown_k_test.rb
+++ b/test/services/jasper/unknown_k_test.rb
@@ -13,7 +13,7 @@ module Jasper
 
     test 'captures free sequence' do
       cat = Category.find_for_cat_aircat('Advanced', 'P')
-      flight = @contest.flights.where(sequence: 2, category_id: cat.id).first
+      flight = cat.flights.find_by(sequence: 2, contest: @contest)
       refute_nil(flight)
       pilot = Member.where(:family_name => 'Lovell').first
       refute_nil(pilot)
@@ -30,7 +30,7 @@ module Jasper
 
     test 'captures free unknown sequence' do
       cat = Category.find_for_cat_aircat('Advanced', 'P')
-      flight = @contest.flights.where(sequence: 3, category_id: cat.id).first
+      flight = cat.flights.find_by(sequence: 3, contest: @contest)
       refute_nil(flight)
       pilot = Member.where(:family_name => 'Lovell').first
       refute_nil(pilot)
@@ -47,7 +47,7 @@ module Jasper
 
     test 'captures second free unknown sequence' do
       cat = Category.find_for_cat_aircat('Advanced', 'P')
-      flight = @contest.flights.where(sequence: 4, category_id: cat.id).first
+      flight = cat.flights.find_by(sequence: 4, contest: @contest)
       refute_nil(flight)
       pilot = Member.where(:family_name => 'Lovell').first
       refute_nil(pilot)

--- a/test/shared/basic_contest_data.rb
+++ b/test/shared/basic_contest_data.rb
@@ -1,0 +1,21 @@
+require 'test_helper'
+
+module BasicContestData
+  def setup_basic_contest_data
+    @contest = create :contest
+    judge_pairs = create_list :judge, 3
+    @pilots = create_list :member, 3
+    @airplanes = create_list :airplane, 3
+    @flights = create_list :flight, 3, contest: @contest
+    @flights.each do |flight|
+      @pilots.each_with_index do |p, i|
+        pf = create :pilot_flight, flight: flight, pilot: p,
+          airplane: @airplanes[i]
+        judge_pairs.each do |j|
+          s = create :score, pilot_flight: pf, judge: j
+        end
+      end
+    end
+    @judges = judge_pairs.collect { |jp| jp.judge }
+  end
+end

--- a/test/shared/basic_contest_data.rb
+++ b/test/shared/basic_contest_data.rb
@@ -6,7 +6,11 @@ module BasicContestData
     judge_pairs = create_list :judge, 3
     @pilots = create_list :member, 3
     @airplanes = create_list :airplane, 3
-    @flights = create_list :flight, 3, contest: @contest
+    flight_names = ['Known', 'Free', 'Unknown', 'Unknown II']
+    @flights = []
+    flight_names.each do |name|
+      @flights << create(:flight, contest: @contest, name: name)
+    end
     @flights.each do |flight|
       @pilots.each_with_index do |p, i|
         pf = create :pilot_flight, flight: flight, pilot: p,

--- a/test/shared/hors_concours_data.rb
+++ b/test/shared/hors_concours_data.rb
@@ -38,5 +38,29 @@ module HorsConcoursData
     computer = ContestComputer.new(@contest)
     computer.compute_results
   end
-end
 
+  def create_pilot_flights(flight, pilots)
+    sequence = create(:sequence)
+    pilots.collect do |pilot|
+      create(:pilot_flight, pilot: pilot, flight: flight, sequence: sequence)
+    end
+  end
+
+  def setup_hors_concours_flights
+    @lower_cat = Category.find_by(aircat: 'P', category: 'sportsman')
+    @higher_cat = Category.find_by(aircat: 'P', category: 'advanced')
+    @glider_cat = Category.find_by(aircat: 'G', category: 'sportsman')
+    @solo_cat = Category.find_by(aircat: 'P', category: 'unlimited')
+    @contest = create(:contest)
+    @pilots = create_list(:member, 7)
+
+    known_flight = create(:flight,
+      contest: @contest, category_id: @higher_cat.id)
+    @known_flights = create_pilot_flights(known_flight, @pilots)
+
+    unknown_flight = create(:flight,
+      name: 'Unknown', contest: @contest, category_id: @higher_cat.id)
+    unknown_sequence = create(:sequence)
+    @unknown_flights = create_pilot_flights(unknown_flight, @pilots)
+  end
+end

--- a/test/shared/hors_concours_data.rb
+++ b/test/shared/hors_concours_data.rb
@@ -4,7 +4,8 @@ module HorsConcoursData
   def setup_hors_concours_data
     judges = create_list(:judge, 3)
 
-    @known_flight = create(:flight)
+    category = create(:category)
+    @known_flight = create(:flight, category_id: category.id)
     @contest = @known_flight.contest
     known_sequence = create(:sequence)
     known_flights = create_list(:pilot_flight, 7, flight: @known_flight,
@@ -17,7 +18,7 @@ module HorsConcoursData
     end
 
     unknown_flight = create(:flight, name: 'Unknown',
-      contest: @contest, category: @known_flight.category)
+      contest: @contest, category_id: category.id)
     unknown_sequence = create(:sequence)
     unknown_flights = {}
     known_flights.each_with_index do |kpf, i|


### PR DESCRIPTION
Closes #22 

This is an alternative implementation to PR #128 

Instead of copying flights, this introduces a many to many relationship between categories and flights, enabling flights to be assigned to more than one category. The synthesis simply adds a relation to the synthesized category.

Places in the code that reference flights for retrieval and reporting specify the category where required.