### PR TITLE
Add has_results to contests.json

### DIFF
--- a/app/models/contest.rb
+++ b/app/models/contest.rb
@@ -54,6 +54,4 @@ class Contest < ApplicationRecord
     jc_results.destroy_all
     failures.destroy_all
   end
-
 end
-

--- a/app/models/contest/show_results.rb
+++ b/app/models/contest/show_results.rb
@@ -114,4 +114,3 @@ module Contest::ShowResults
     categories
   end
 end
-

--- a/app/views/contests/_contest.json.jbuilder
+++ b/app/views/contests/_contest.json.jbuilder
@@ -1,2 +1,3 @@
 json.(contest, :id, :name, :city, :state, :start, :chapter, :director, :region)
+json.has_results !contest.flights.empty?
 json.url contest_url(contest, :format => :json)

--- a/test/controllers/contests_controller/index_test.rb
+++ b/test/controllers/contests_controller/index_test.rb
@@ -48,4 +48,11 @@ class ContestsController::IndexTest < ActionController::TestCase
     assert_equal(1, years.uniq.count)
     assert_equal(@year, years.first)
   end
+
+  test 'responds with has_results flag' do
+    get :index, :format => :json
+    data = JSON.parse(response.body)
+    contest = data['contests'].first
+    assert_false(contest.fetch('has_results', true))
+  end
 end


### PR DESCRIPTION
Edit the contests json output to include a flag indicating whether the contest has any results.

We use whether there are any flights associated with the contest. Elsewhere, in the html view, the indicator is whether there has been a data post AND whether there are any flights. For the api, whether the data arrived by post is irrelevant. The same case could be made for the html view; but, I'm leaving it as is.