### PR TITLE
Prevent render json assistant for judge if not present

### DIFF
--- a/app/views/pilot_flights/_judge_pair.json.jbuilder
+++ b/app/views/pilot_flights/_judge_pair.json.jbuilder
@@ -2,7 +2,8 @@ json.judge do
   json.(jp.judge, :id, :name)
   json.url judge_url(jp.judge, :format => :json)
 end
-json.assistant do
-  json.(jp.assist, :id, :name)
+if (jp.assist)
+  json.assistant do
+    json.(jp.assist, :id, :name)
+  end
 end
-

--- a/test/controllers/pilot_flight_controller_test.rb
+++ b/test/controllers/pilot_flight_controller_test.rb
@@ -1,0 +1,14 @@
+require 'test_helper'
+
+class PilotFlightControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    @pf = create(:pilot_flight)
+    judge = create(:judge, assist: nil)
+    score = create(:score, pilot_flight: @pf, judge: judge)
+  end
+
+  test "should get show json" do
+    get pilot_flight_path(@pf, format: :json)
+    assert_response :success
+  end
+end


### PR DESCRIPTION
Guards the assistant output of a judge pair against nil assistant when rendering a pilot_flight.

Closes #144