### PR TITLE
Provide command line utility for merging contests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,7 @@
 .gems*
 .bundle
 db/*.sqlite3*
-log/*.log
+log/
 tmp/**/*
 vendor/cache
 posts/
@@ -15,4 +15,3 @@ public/assets
 config/database.yml
 *.dia~
 coverage/
-

--- a/app/services/contest_merge_service.rb
+++ b/app/services/contest_merge_service.rb
@@ -1,9 +1,32 @@
 class ContestMergeService
+  attr_reader :categories
+
+  class CategoryOverlapError < ArgumentError
+    attr_reader :overlapping_categories
+
+    def initialize(overlap)
+      super("Category overlap for #{overlap.map(&:name).join(', ')}")
+      @overlapping_categories = overlap
+    end
+  end
+
   def initialize(contest)
     @contest = contest
+    @categories = contest_categories(contest)
+  end
+
+  def contest_categories(contest)
+    [
+      contest.flights.map(&:categories).map(&:to_a),
+      contest.jc_results.map(&:category),
+      contest.pc_results.map(&:category)
+    ].flatten.uniq
   end
 
   def merge_contest(other_contest)
+    other_cats = contest_categories(other_contest)
+    overlap = other_cats & categories
+    raise CategoryOverlapError.new(overlap) unless (overlap).empty?
     other_contest.jc_results.update_all(contest_id: @contest.id)
     other_contest.pc_results.update_all(contest_id: @contest.id)
     other_contest.flights.update_all(contest_id: @contest.id)

--- a/app/services/contest_merge_service.rb
+++ b/app/services/contest_merge_service.rb
@@ -1,0 +1,11 @@
+class ContestMergeService
+  def initialize(contest)
+    @contest = contest
+  end
+
+  def merge_contest(other_contest)
+    other_contest.jc_results.update_all(contest_id: @contest.id)
+    other_contest.pc_results.update_all(contest_id: @contest.id)
+    other_contest.flights.update_all(contest_id: @contest.id)
+  end
+end

--- a/cmd/merge_contests.rb
+++ b/cmd/merge_contests.rb
@@ -1,0 +1,28 @@
+# use rails runner cmd/merge_contests.rb
+# will merge a second contest into the first
+
+def helps
+  puts 'Merges the second specified contest into the first'
+  puts 'Specify two contest identifiers.'
+end
+
+def do_merger(target, other)
+  merger = ContestMergeService.new(target)
+  merger.merge_contest(other)
+  puts "Contest #{other.name} merged into #{target.name}"
+end
+
+if (ARGV.length == 2)
+  begin
+    target = Contest.find(ARGV[0])
+    other = Contest.find(ARGV[1])
+    puts "Contest #{other.name} to be merged into #{target.name}"
+    print 'Type "yes" and press enter to confirm, anything else to cancel: '
+    do_merger(target, other) if (STDIN.gets.strip.downcase.eql?("yes"))
+  rescue => e
+    helps
+    puts "Error is #{e.message}"
+  end
+else
+  helps
+end

--- a/spec/factories/model.rb
+++ b/spec/factories/model.rb
@@ -102,7 +102,7 @@ FactoryBot.define do
   end
 ### Category
   factory :category do
-    transient do 
+    transient do
       category { 'intermediate' }
       aircat { 'P' }
       seq { (Category.pluck(:sequence).max || 0) + 1 }
@@ -114,8 +114,8 @@ FactoryBot.define do
       ).order(:sequence).first
       unless factory_cat
         factory_cat = Category.create(
-          category: category, aircat: aircat, sequence: seq,
-          name: (name || Faker::Book.unique.title)
+          category: category.slice(0,16), aircat: aircat, sequence: seq,
+          name: (name || Faker::Book.unique.title.slice(0,48))
         )
       end
       factory_cat

--- a/test/services/contest_merge_test.rb
+++ b/test/services/contest_merge_test.rb
@@ -1,0 +1,37 @@
+require 'test_helper'
+require 'shared/basic_contest_data'
+
+class ContestMergeTest < ActiveSupport::TestCase
+  include BasicContestData
+
+  def create_complete_contest(categories)
+    setup_basic_contest_data(categories)
+    cc = ContestComputer.new(@contest)
+    cc.compute_results
+    @contest
+  end
+
+  setup do
+    @power_contest = create_complete_contest(Category.where(aircat: 'P'))
+    @glider_contest = create_complete_contest(Category.where(aircat: 'G'))
+    @ctst_merge = ContestMergeService.new(@power_contest)
+  end
+
+  test 'moves relations' do
+    jcrs = @glider_contest.jc_results.pluck(:id)
+    pcrs = @glider_contest.pc_results.pluck(:id)
+    flts = @glider_contest.flights.pluck(:id)
+    assert_operator(0, :<, jcrs.length)
+    assert_operator(0, :<, pcrs.length)
+    assert_operator(0, :<, flts.length)
+    @ctst_merge.merge_contest(@glider_contest)
+    @power_contest.reload
+    @glider_contest.reload
+    assert_equal(0, @glider_contest.jc_results.count)
+    assert_equal(0, @glider_contest.pc_results.count)
+    assert_equal(0, @glider_contest.flights.count)
+    assert_equal(jcrs, jcrs & @power_contest.jc_results.pluck(:id))
+    assert_equal(pcrs, pcrs & @power_contest.pc_results.pluck(:id))
+    assert_equal(flts, flts & @power_contest.flights.pluck(:id))
+  end
+end

--- a/test/shared/basic_contest_data.rb
+++ b/test/shared/basic_contest_data.rb
@@ -1,15 +1,19 @@
 require 'test_helper'
 
 module BasicContestData
-  def setup_basic_contest_data
+  def setup_basic_contest_data(categories=nil)
     @contest = create :contest
     judge_pairs = create_list :judge, 3
     @pilots = create_list :member, 3
     @airplanes = create_list :airplane, 3
     flight_names = ['Known', 'Free', 'Unknown', 'Unknown II']
     @flights = []
-    flight_names.each do |name|
-      @flights << create(:flight, contest: @contest, name: name)
+    categories = [Category.first] unless categories
+    categories.each do |cat|
+      flight_names.each do |name|
+        @flights << create(:flight,
+          contest: @contest, name: name, category_id: cat.id)
+      end
     end
     @flights.each do |flight|
       @pilots.each_with_index do |p, i|


### PR DESCRIPTION
Closes #141 

Rather than incorporating logic into the Soucy result computer to treat two nationals contests as one, provides a tested utility to merge the Power and Glider separate Nationals contests into one contest.